### PR TITLE
Fix typo in error message

### DIFF
--- a/signserver/modules/SignServer-Client-CLI/src/main/java/org/signserver/client/cli/defaultimpl/DefaultFileSpecificHandlerFactory.java
+++ b/signserver/modules/SignServer-Client-CLI/src/main/java/org/signserver/client/cli/defaultimpl/DefaultFileSpecificHandlerFactory.java
@@ -31,7 +31,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final boolean clientSide, Map<String, String> extraOptions)
             throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side contruction is not supported");
+            throw new IllegalArgumentException("Client-side construction is not supported");
         }
         return new StraightFileSpecificHandler((inFile), inFile.length());
     }
@@ -43,7 +43,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final String workerName)
             throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side contruction is not supported");
+            throw new IllegalArgumentException("Client-side construction is not supported");
         }
         return new StraightFileSpecificHandler((inFile), inFile.length());
     }
@@ -58,7 +58,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final Map<String, String> metadata)
             throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side contruction is not supported");
+            throw new IllegalArgumentException("Client-side construction is not supported");
         }
         return new StraightFileSpecificHandler((inFile), inFile.length());
     }
@@ -70,7 +70,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final int workerId)
             throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side contruction is not supported");
+            throw new IllegalArgumentException("Client-side construction is not supported");
         }
         return new StraightFileSpecificHandler((inFile), inFile.length());
     }
@@ -85,7 +85,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final Map<String, String> metadata)
             throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side contruction is not supported");
+            throw new IllegalArgumentException("Client-side construction is not supported");
         }
         return new StraightFileSpecificHandler((inFile), inFile.length());
     }
@@ -93,7 +93,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
     @Override
     public FileSpecificHandler createHandler(final byte[] inData, final File outFile, final boolean clientSide, Map<String, String> extraOptions) {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side contruction is not supported");
+            throw new IllegalArgumentException("Client-side construction is not supported");
         }
         return new StraightFileSpecificHandler(inData);
     }
@@ -105,7 +105,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final boolean clientSide, Map<String, String> extraOptions)
         throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side contruction is not supported");
+            throw new IllegalArgumentException("Client-side construction is not supported");
         }
         return new StraightFileSpecificHandler(inFile,
                                                inFile.length());
@@ -120,7 +120,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final String workerName)
         throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side contruction is not supported");
+            throw new IllegalArgumentException("Client-side construction is not supported");
         }
         return new StraightFileSpecificHandler(inFile,
                                                inFile.length());
@@ -138,7 +138,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final Map<String, String> metadata)
         throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side contruction is not supported");
+            throw new IllegalArgumentException("Client-side construction is not supported");
         }
         return new StraightFileSpecificHandler((inFile),
                                                inFile.length());
@@ -153,7 +153,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final int workerId)
         throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side contruction is not supported");
+            throw new IllegalArgumentException("Client-side construction is not supported");
         }
         return new StraightFileSpecificHandler((inFile),
                                                inFile.length());
@@ -171,7 +171,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final Map<String, String> metadata)
         throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side contruction is not supported");
+            throw new IllegalArgumentException("Client-side construction is not supported");
         }
         return new StraightFileSpecificHandler((inFile),
                                                inFile.length());
@@ -183,7 +183,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final File outFile,
                                              final boolean clientSide, Map<String, String> extraOptions) {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side contruction is not supported");
+            throw new IllegalArgumentException("Client-side construction is not supported");
         }
         return new StraightFileSpecificHandler(inData);
     }

--- a/signserver/modules/SignServer-Client-CLI/src/main/java/org/signserver/client/cli/defaultimpl/DefaultFileSpecificHandlerFactory.java
+++ b/signserver/modules/SignServer-Client-CLI/src/main/java/org/signserver/client/cli/defaultimpl/DefaultFileSpecificHandlerFactory.java
@@ -26,12 +26,15 @@ import org.signserver.client.cli.spi.FileSpecificHandlerFactory;
  */
 public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFactory {
 
+    public static final String NO_CLIENT_SIDE_CONSTRUCTION_AVAILABLE = "No client-side construction implementation " +
+            "available, does your version support it?\nSee https://doc.primekey.com/x/ewFu";
+
     @Override
     public FileSpecificHandler createHandler(final File inFile, final File outFile,
                                              final boolean clientSide, Map<String, String> extraOptions)
             throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
+            throw new IllegalArgumentException(NO_CLIENT_SIDE_CONSTRUCTION_AVAILABLE);
         }
         return new StraightFileSpecificHandler((inFile), inFile.length());
     }
@@ -43,7 +46,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final String workerName)
             throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
+            throw new IllegalArgumentException(NO_CLIENT_SIDE_CONSTRUCTION_AVAILABLE);
         }
         return new StraightFileSpecificHandler((inFile), inFile.length());
     }
@@ -58,7 +61,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final Map<String, String> metadata)
             throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
+            throw new IllegalArgumentException(NO_CLIENT_SIDE_CONSTRUCTION_AVAILABLE);
         }
         return new StraightFileSpecificHandler((inFile), inFile.length());
     }
@@ -70,7 +73,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final int workerId)
             throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
+            throw new IllegalArgumentException(NO_CLIENT_SIDE_CONSTRUCTION_AVAILABLE);
         }
         return new StraightFileSpecificHandler((inFile), inFile.length());
     }
@@ -85,7 +88,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final Map<String, String> metadata)
             throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
+            throw new IllegalArgumentException(NO_CLIENT_SIDE_CONSTRUCTION_AVAILABLE);
         }
         return new StraightFileSpecificHandler((inFile), inFile.length());
     }
@@ -93,7 +96,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
     @Override
     public FileSpecificHandler createHandler(final byte[] inData, final File outFile, final boolean clientSide, Map<String, String> extraOptions) {
         if (clientSide) {
-            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
+            throw new IllegalArgumentException(NO_CLIENT_SIDE_CONSTRUCTION_AVAILABLE);
         }
         return new StraightFileSpecificHandler(inData);
     }
@@ -105,7 +108,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final boolean clientSide, Map<String, String> extraOptions)
         throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
+            throw new IllegalArgumentException(NO_CLIENT_SIDE_CONSTRUCTION_AVAILABLE);
         }
         return new StraightFileSpecificHandler(inFile,
                                                inFile.length());
@@ -120,7 +123,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final String workerName)
         throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
+            throw new IllegalArgumentException(NO_CLIENT_SIDE_CONSTRUCTION_AVAILABLE);
         }
         return new StraightFileSpecificHandler(inFile,
                                                inFile.length());
@@ -138,7 +141,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final Map<String, String> metadata)
         throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
+            throw new IllegalArgumentException(NO_CLIENT_SIDE_CONSTRUCTION_AVAILABLE);
         }
         return new StraightFileSpecificHandler((inFile),
                                                inFile.length());
@@ -153,7 +156,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final int workerId)
         throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
+            throw new IllegalArgumentException(NO_CLIENT_SIDE_CONSTRUCTION_AVAILABLE);
         }
         return new StraightFileSpecificHandler((inFile),
                                                inFile.length());
@@ -171,7 +174,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final Map<String, String> metadata)
         throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
+            throw new IllegalArgumentException(NO_CLIENT_SIDE_CONSTRUCTION_AVAILABLE);
         }
         return new StraightFileSpecificHandler((inFile),
                                                inFile.length());
@@ -183,7 +186,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final File outFile,
                                              final boolean clientSide, Map<String, String> extraOptions) {
         if (clientSide) {
-            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
+            throw new IllegalArgumentException(NO_CLIENT_SIDE_CONSTRUCTION_AVAILABLE);
         }
         return new StraightFileSpecificHandler(inData);
     }

--- a/signserver/modules/SignServer-Client-CLI/src/main/java/org/signserver/client/cli/defaultimpl/DefaultFileSpecificHandlerFactory.java
+++ b/signserver/modules/SignServer-Client-CLI/src/main/java/org/signserver/client/cli/defaultimpl/DefaultFileSpecificHandlerFactory.java
@@ -31,7 +31,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final boolean clientSide, Map<String, String> extraOptions)
             throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side construction is not supported");
+            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
         }
         return new StraightFileSpecificHandler((inFile), inFile.length());
     }
@@ -43,7 +43,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final String workerName)
             throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side construction is not supported");
+            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
         }
         return new StraightFileSpecificHandler((inFile), inFile.length());
     }
@@ -58,7 +58,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final Map<String, String> metadata)
             throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side construction is not supported");
+            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
         }
         return new StraightFileSpecificHandler((inFile), inFile.length());
     }
@@ -70,7 +70,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final int workerId)
             throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side construction is not supported");
+            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
         }
         return new StraightFileSpecificHandler((inFile), inFile.length());
     }
@@ -85,7 +85,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final Map<String, String> metadata)
             throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side construction is not supported");
+            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
         }
         return new StraightFileSpecificHandler((inFile), inFile.length());
     }
@@ -93,7 +93,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
     @Override
     public FileSpecificHandler createHandler(final byte[] inData, final File outFile, final boolean clientSide, Map<String, String> extraOptions) {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side construction is not supported");
+            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
         }
         return new StraightFileSpecificHandler(inData);
     }
@@ -105,7 +105,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final boolean clientSide, Map<String, String> extraOptions)
         throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side construction is not supported");
+            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
         }
         return new StraightFileSpecificHandler(inFile,
                                                inFile.length());
@@ -120,7 +120,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final String workerName)
         throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side construction is not supported");
+            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
         }
         return new StraightFileSpecificHandler(inFile,
                                                inFile.length());
@@ -138,7 +138,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final Map<String, String> metadata)
         throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side construction is not supported");
+            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
         }
         return new StraightFileSpecificHandler((inFile),
                                                inFile.length());
@@ -153,7 +153,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final int workerId)
         throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side construction is not supported");
+            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
         }
         return new StraightFileSpecificHandler((inFile),
                                                inFile.length());
@@ -171,7 +171,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final Map<String, String> metadata)
         throws IOException {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side construction is not supported");
+            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
         }
         return new StraightFileSpecificHandler((inFile),
                                                inFile.length());
@@ -183,7 +183,7 @@ public class DefaultFileSpecificHandlerFactory implements FileSpecificHandlerFac
                                              final File outFile,
                                              final boolean clientSide, Map<String, String> extraOptions) {
         if (clientSide) {
-            throw new IllegalArgumentException("Client-side construction is not supported");
+            throw new IllegalArgumentException("No client-side construction implementation available, does your version support it?\nSee https://doc.primekey.com/x/ewFu");
         }
         return new StraightFileSpecificHandler(inData);
     }

--- a/signserver/modules/SignServer-Client-CLI/src/main/java/org/signserver/client/cli/defaultimpl/DocumentSignerFactory.java
+++ b/signserver/modules/SignServer-Client-CLI/src/main/java/org/signserver/client/cli/defaultimpl/DocumentSignerFactory.java
@@ -104,7 +104,7 @@ public class DocumentSignerFactory {
      * 
      * @param workerName Worker name to send the request to
      * @param metadata Metadata to include in the request
-     * @param clientSide True if the request is using client-side hashing and contruction
+     * @param clientSide True if the request is using client-side hashing and construction
      * @param isSignatureInputHash True if input is a hash
      * @param typeId File type
      * @return DocumentSigner instance for sending the request given the parameters
@@ -123,7 +123,7 @@ public class DocumentSignerFactory {
      * 
      * @param workerId Worker ID to send the request to
      * @param metadata Metadata to include in the request
-     * @param clientSide True if the request is using client-side hashing and contruction
+     * @param clientSide True if the request is using client-side hashing and construction
      * @param isSignatureInputHash True if input is a hash
      * @param typeId File type
      * @return DocumentSigner instance for sending the request given the parameters

--- a/signserver/modules/SignServer-Client-CLI/src/main/java/org/signserver/client/cli/defaultimpl/SignDocumentCommand.java
+++ b/signserver/modules/SignServer-Client-CLI/src/main/java/org/signserver/client/cli/defaultimpl/SignDocumentCommand.java
@@ -729,7 +729,7 @@ public class SignDocumentCommand extends AbstractCommand implements ConsolePassw
         if (rejectedFileType) {
             throw new CommandFailureException("Could not find file handler factory supporting file type: " + fileType);
         } else {
-            throw new CommandFailureException("Client-side hashing and contruction is not supported");
+            throw new CommandFailureException("Client-side hashing and construction is not supported");
         }
     }
 

--- a/signserver/modules/SignServer-Client-CLI/src/main/java/org/signserver/client/cli/spi/FileSpecificHandlerFactory.java
+++ b/signserver/modules/SignServer-Client-CLI/src/main/java/org/signserver/client/cli/spi/FileSpecificHandlerFactory.java
@@ -255,7 +255,7 @@ public interface FileSpecificHandlerFactory {
     
     /**
      * Return true if the factory can create a client-side hashing and
-     * contruction-capable handler.
+     * construction-capable handler.
      * 
      * @return True if can create client-side capable handler
      */


### PR DESCRIPTION
When attempting to use signClient with `-clientside` I get an error message that contains a typo.