### PR TITLE
Update Jsign to 5.0

### DIFF
--- a/signserver/pom.xml
+++ b/signserver/pom.xml
@@ -353,9 +353,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.signserver.jsign</groupId>
+                <groupId>net.jsign</groupId>
                 <artifactId>jsign-core</artifactId>
-                <version>3.1-signserver5.5</version>
+                <version>5.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
The changes from the forked 3.1-signserver5.5 version were merged in the version 4.0, and several improvements relevant to signserver have been made:
- Large MSI files are now supported
- APPX/MSIX support
- Several OutOfMemoryError caused by invalid input files have been fixed 