### PR TITLE
Transaction support for signing and timed service - 2

### DIFF
--- a/signserver/modules/SignServer-Common/src/main/java/org/signserver/common/SignServerConstants.java
+++ b/signserver/modules/SignServer-Common/src/main/java/org/signserver/common/SignServerConstants.java
@@ -27,54 +27,54 @@ public class SignServerConstants {
      * Set propery to TRUE to disable the signer.
      */
     public static final String DISABLED = "DISABLED";
-
+    
     /**
      * Constant indicating that the signserver archive the response data.
      * Set propery to TRUE to start archiving
      */
     public static final String ARCHIVE = "ARCHIVE";
-
+    
     /**
      * Property with list of Archiver implementation classes.
      */
     public static String ARCHIVERS = "ARCHIVERS";
-
+    
     /**
      * Constant indicating which module that should be used with
      * the cluster class loader.
      */
     public static final String MODULENAME = "MODULENAME";
-
+    
     /**
      * Constant indicating which module version that should be used
      * by the cluster class loader for the given worker.
-     *
+     * 
      * If no module version is specified will the latest available
      * version be used.
      */
     public static final String MODULEVERSION = "MODULEVERSION";
-
+    
     /**
      * Constant indicating if JPA should be used with the cluster
      * class loader, it is used to create DB access for a specific
      * worker in a MAR file.
-     *
-     *
+     * 
+     * 
      */
     public static final String USEWORKERENTITYMANAGER = "USEWORKERENTITYMANAGER";
-
+    
     /**
      * Constant indicating that a signers certificate should be checked for validity.
      * Set property to FALSE to ignore if the validity is not yet valid or has expired.
      */
     public static final String CHECKCERTVALIDITY = "CHECKCERTVALIDITY";
-
+    
     /**
      * Constant indicating that a signers certificate should be checked for validity of the private key (using the PrivateKeyUsagePeriod).
      * Set property to FALSE to ignore if the private key usage period is not yet valid or has expired.
      */
     public static final String CHECKCERTPRIVATEKEYVALIDITY = "CHECKCERTPRIVATEKEYVALIDITY";
-
+    
     /**
      * Constant defining a minimum remaining certificate validity period for the signer to work. If the signer certificate has 
      * less days validity remaining than the number of days specified by this property, the signer will not work.
@@ -82,22 +82,19 @@ public class SignServerConstants {
      * A value of 0 means unlimited, i.e. the property is not used.
      */
     public static final String MINREMAININGCERTVALIDITY = "MINREMAININGCERTVALIDITY";
-
+    
     /**
      * Maximum number signings that are allowed to be performed by a key.
      * A negative value means no limit (default).
      */
     public static final String KEYUSAGELIMIT = "KEYUSAGELIMIT";
     public static String DISABLEKEYUSAGECOUNTER = "DISABLEKEYUSAGECOUNTER";
-
-    public static String PROCESSINTRANSACTION = "PROCESSINTRANSACTION";
-
     /**
      * Constant used to set the default value of configuration property to NULL if not setting property means property value is NULL.
-     *
+     * 
      */
     public static final String DEFAULT_NULL = null;
-
+    
     public static final String TOKEN_ENTRY_FIELDS_ALIAS = "alias";        // Old criteria column name that still need to be supported for client interfaces
     public static final String TOKEN_ENTRY_FIELDS_KEY_ALIAS = "keyAlias"; // Current criteria column name and defined in CryptoTokenHelper.TokenEntryFields
 

--- a/signserver/modules/SignServer-Common/src/main/java/org/signserver/common/SignServerConstants.java
+++ b/signserver/modules/SignServer-Common/src/main/java/org/signserver/common/SignServerConstants.java
@@ -27,54 +27,54 @@ public class SignServerConstants {
      * Set propery to TRUE to disable the signer.
      */
     public static final String DISABLED = "DISABLED";
-    
+
     /**
      * Constant indicating that the signserver archive the response data.
      * Set propery to TRUE to start archiving
      */
     public static final String ARCHIVE = "ARCHIVE";
-    
+
     /**
      * Property with list of Archiver implementation classes.
      */
     public static String ARCHIVERS = "ARCHIVERS";
-    
+
     /**
      * Constant indicating which module that should be used with
      * the cluster class loader.
      */
     public static final String MODULENAME = "MODULENAME";
-    
+
     /**
      * Constant indicating which module version that should be used
      * by the cluster class loader for the given worker.
-     * 
+     *
      * If no module version is specified will the latest available
      * version be used.
      */
     public static final String MODULEVERSION = "MODULEVERSION";
-    
+
     /**
      * Constant indicating if JPA should be used with the cluster
      * class loader, it is used to create DB access for a specific
      * worker in a MAR file.
-     * 
-     * 
+     *
+     *
      */
     public static final String USEWORKERENTITYMANAGER = "USEWORKERENTITYMANAGER";
-    
+
     /**
      * Constant indicating that a signers certificate should be checked for validity.
      * Set property to FALSE to ignore if the validity is not yet valid or has expired.
      */
     public static final String CHECKCERTVALIDITY = "CHECKCERTVALIDITY";
-    
+
     /**
      * Constant indicating that a signers certificate should be checked for validity of the private key (using the PrivateKeyUsagePeriod).
      * Set property to FALSE to ignore if the private key usage period is not yet valid or has expired.
      */
     public static final String CHECKCERTPRIVATEKEYVALIDITY = "CHECKCERTPRIVATEKEYVALIDITY";
-    
+
     /**
      * Constant defining a minimum remaining certificate validity period for the signer to work. If the signer certificate has 
      * less days validity remaining than the number of days specified by this property, the signer will not work.
@@ -82,19 +82,22 @@ public class SignServerConstants {
      * A value of 0 means unlimited, i.e. the property is not used.
      */
     public static final String MINREMAININGCERTVALIDITY = "MINREMAININGCERTVALIDITY";
-    
+
     /**
      * Maximum number signings that are allowed to be performed by a key.
      * A negative value means no limit (default).
      */
     public static final String KEYUSAGELIMIT = "KEYUSAGELIMIT";
     public static String DISABLEKEYUSAGECOUNTER = "DISABLEKEYUSAGECOUNTER";
+
+    public static String PROCESSINTRANSACTION = "PROCESSINTRANSACTION";
+
     /**
      * Constant used to set the default value of configuration property to NULL if not setting property means property value is NULL.
-     * 
+     *
      */
     public static final String DEFAULT_NULL = null;
-    
+
     public static final String TOKEN_ENTRY_FIELDS_ALIAS = "alias";        // Old criteria column name that still need to be supported for client interfaces
     public static final String TOKEN_ENTRY_FIELDS_KEY_ALIAS = "keyAlias"; // Current criteria column name and defined in CryptoTokenHelper.TokenEntryFields
 

--- a/signserver/modules/SignServer-Common/src/main/java/org/signserver/common/SignServerConstants.java
+++ b/signserver/modules/SignServer-Common/src/main/java/org/signserver/common/SignServerConstants.java
@@ -89,6 +89,9 @@ public class SignServerConstants {
      */
     public static final String KEYUSAGELIMIT = "KEYUSAGELIMIT";
     public static String DISABLEKEYUSAGECOUNTER = "DISABLEKEYUSAGECOUNTER";
+
+    public static String PROCESSINTRANSACTION = "PROCESSINTRANSACTION";
+
     /**
      * Constant used to set the default value of configuration property to NULL if not setting property means property value is NULL.
      * 

--- a/signserver/modules/SignServer-Server/src/main/java/org/cesecore/keys/token/KeyAliasesCache.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/cesecore/keys/token/KeyAliasesCache.java
@@ -23,12 +23,18 @@ import org.signserver.server.cesecore.internal.CommonCacheBase;
  */
 public class KeyAliasesCache extends CommonCacheBase<PublicKey> {
 
+    long lastUpdate = 0L;
+
     @Override
     public PublicKey getEntry(final Integer id) {
         if (id == null) {
             return null;
         }
         return super.getEntry(id);
+    }
+
+    public void updateCacheTimeStamp() {
+        this.lastUpdate = System.currentTimeMillis();
     }
 
     @Override

--- a/signserver/modules/SignServer-Server/src/main/java/org/cesecore/keys/token/KeyAliasesCache.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/cesecore/keys/token/KeyAliasesCache.java
@@ -18,10 +18,12 @@ import org.signserver.server.cesecore.internal.CommonCacheBase;
 
 /**
  * Cache for Key aliases (used in Azure Crypto Token, but is generic). Caches a public key, with alias as key
- * 
+ *
  * @version $Id$
  */
 public class KeyAliasesCache extends CommonCacheBase<PublicKey> {
+
+    long lastUpdate = 0L;
 
     @Override
     public PublicKey getEntry(final Integer id) {
@@ -29,6 +31,10 @@ public class KeyAliasesCache extends CommonCacheBase<PublicKey> {
             return null;
         }
         return super.getEntry(id);
+    }
+
+    public void updateCacheTimeStamp() {
+        this.lastUpdate = System.currentTimeMillis();
     }
 
     @Override

--- a/signserver/modules/SignServer-Server/src/main/java/org/cesecore/keys/token/KeyAliasesCache.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/cesecore/keys/token/KeyAliasesCache.java
@@ -18,12 +18,10 @@ import org.signserver.server.cesecore.internal.CommonCacheBase;
 
 /**
  * Cache for Key aliases (used in Azure Crypto Token, but is generic). Caches a public key, with alias as key
- *
+ * 
  * @version $Id$
  */
 public class KeyAliasesCache extends CommonCacheBase<PublicKey> {
-
-    long lastUpdate = 0L;
 
     @Override
     public PublicKey getEntry(final Integer id) {
@@ -31,10 +29,6 @@ public class KeyAliasesCache extends CommonCacheBase<PublicKey> {
             return null;
         }
         return super.getEntry(id);
-    }
-
-    public void updateCacheTimeStamp() {
-        this.lastUpdate = System.currentTimeMillis();
     }
 
     @Override

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/BaseWorker.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/BaseWorker.java
@@ -38,20 +38,20 @@ public abstract class BaseWorker implements IWorker {
     /** Logger. */
     private static final Logger LOG = Logger.getLogger(BaseWorker.class);
 
-            
+
     //Private Property constants
     protected int workerId = 0;
     protected WorkerConfig config = null;
     protected WorkerContext workerContext;
     private List<String> fatalErrors;
-    /** 
+    /**
      * @deprecated This EntityManager was created when the worker was 
      * initialized and is not safe to use from an other transaction. Instead 
      * use the entity manager available in the RequestContext.
      */
     @Deprecated
     protected EntityManager em;
-    /** 
+    /**
      * @deprecated This EntityManager was created when the worker was 
      * initialized and is not safe to use from an other transaction. Instead 
      * use the entity manager available in the RequestContext.
@@ -89,7 +89,7 @@ public abstract class BaseWorker implements IWorker {
             values.remove(WorkerType.UNKNOWN);
             fatalErrors.add("Incorrect Worker TYPE: " + ex.getMessage() + ". Specify one of " + values.toString());
         }
-        
+
     }
 
     protected SignServerContext getSignServerContext() {
@@ -106,14 +106,14 @@ public abstract class BaseWorker implements IWorker {
     public WorkerConfig getConfig() {
         return config;
     }
-    
+
     /**
      * Method that can be overridden by IWorker implementations to give an 
      * up to date list of errors that would prevent a call to the process 
      * method to succeed.
      * If the returned list is non empty the worker will be reported as offline 
      * in status listings and by the health check (unless the worker is disabled).
-     * 
+     *
      * @param services Services for the implementations to use
      * @return A list of (short) messages describing each error or an empty list
      * in case there are no errors
@@ -152,8 +152,8 @@ public abstract class BaseWorker implements IWorker {
         Properties properties = config.getProperties();
         for (String key : properties.stringPropertyNames()) {
             final String value = config.shouldMaskProperty(key) ?
-                                 WorkerConfig.WORKER_PROPERTY_MASK_PLACEHOLDER :
-                                 properties.getProperty(key);
+                    WorkerConfig.WORKER_PROPERTY_MASK_PLACEHOLDER :
+                    properties.getProperty(key);
             configValue.append(key).append("=").append(value).append("\n\n");
         }
         completeEntries.add(new WorkerStatusInfo.Entry("Worker properties", configValue.toString()));
@@ -166,13 +166,13 @@ public abstract class BaseWorker implements IWorker {
         completeEntries.add(new WorkerStatusInfo.Entry("Authorized clients (serial number, issuer DN)", clientsValue.toString()));
 
         // Return everything
-        return new WorkerStatusInfo(workerId, 
-                config.getProperty("NAME"), 
-                "Worker", 
-                active ? WorkerStatus.STATUS_ACTIVE : WorkerStatus.STATUS_OFFLINE, 
-                briefEntries, 
-                errors, 
-                completeEntries, 
+        return new WorkerStatusInfo(workerId,
+                config.getProperty("NAME"),
+                "Worker",
+                active ? WorkerStatus.STATUS_ACTIVE : WorkerStatus.STATUS_OFFLINE,
+                briefEntries,
+                errors,
+                completeEntries,
                 config);
     }
 
@@ -208,5 +208,9 @@ public abstract class BaseWorker implements IWorker {
             type = WorkerType.SPECIAL;
         }
         return type;
+    }
+
+    public boolean requiresTransaction(final IServices services) {
+        return false;
     }
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/BaseWorker.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/BaseWorker.java
@@ -38,20 +38,20 @@ public abstract class BaseWorker implements IWorker {
     /** Logger. */
     private static final Logger LOG = Logger.getLogger(BaseWorker.class);
 
-
+            
     //Private Property constants
     protected int workerId = 0;
     protected WorkerConfig config = null;
     protected WorkerContext workerContext;
     private List<String> fatalErrors;
-    /**
+    /** 
      * @deprecated This EntityManager was created when the worker was 
      * initialized and is not safe to use from an other transaction. Instead 
      * use the entity manager available in the RequestContext.
      */
     @Deprecated
     protected EntityManager em;
-    /**
+    /** 
      * @deprecated This EntityManager was created when the worker was 
      * initialized and is not safe to use from an other transaction. Instead 
      * use the entity manager available in the RequestContext.
@@ -89,7 +89,7 @@ public abstract class BaseWorker implements IWorker {
             values.remove(WorkerType.UNKNOWN);
             fatalErrors.add("Incorrect Worker TYPE: " + ex.getMessage() + ". Specify one of " + values.toString());
         }
-
+        
     }
 
     protected SignServerContext getSignServerContext() {
@@ -106,14 +106,14 @@ public abstract class BaseWorker implements IWorker {
     public WorkerConfig getConfig() {
         return config;
     }
-
+    
     /**
      * Method that can be overridden by IWorker implementations to give an 
      * up to date list of errors that would prevent a call to the process 
      * method to succeed.
      * If the returned list is non empty the worker will be reported as offline 
      * in status listings and by the health check (unless the worker is disabled).
-     *
+     * 
      * @param services Services for the implementations to use
      * @return A list of (short) messages describing each error or an empty list
      * in case there are no errors
@@ -152,8 +152,8 @@ public abstract class BaseWorker implements IWorker {
         Properties properties = config.getProperties();
         for (String key : properties.stringPropertyNames()) {
             final String value = config.shouldMaskProperty(key) ?
-                    WorkerConfig.WORKER_PROPERTY_MASK_PLACEHOLDER :
-                    properties.getProperty(key);
+                                 WorkerConfig.WORKER_PROPERTY_MASK_PLACEHOLDER :
+                                 properties.getProperty(key);
             configValue.append(key).append("=").append(value).append("\n\n");
         }
         completeEntries.add(new WorkerStatusInfo.Entry("Worker properties", configValue.toString()));
@@ -166,13 +166,13 @@ public abstract class BaseWorker implements IWorker {
         completeEntries.add(new WorkerStatusInfo.Entry("Authorized clients (serial number, issuer DN)", clientsValue.toString()));
 
         // Return everything
-        return new WorkerStatusInfo(workerId,
-                config.getProperty("NAME"),
-                "Worker",
-                active ? WorkerStatus.STATUS_ACTIVE : WorkerStatus.STATUS_OFFLINE,
-                briefEntries,
-                errors,
-                completeEntries,
+        return new WorkerStatusInfo(workerId, 
+                config.getProperty("NAME"), 
+                "Worker", 
+                active ? WorkerStatus.STATUS_ACTIVE : WorkerStatus.STATUS_OFFLINE, 
+                briefEntries, 
+                errors, 
+                completeEntries, 
                 config);
     }
 
@@ -208,9 +208,5 @@ public abstract class BaseWorker implements IWorker {
             type = WorkerType.SPECIAL;
         }
         return type;
-    }
-
-    public boolean requiresTransaction(final IServices services) {
-        return false;
     }
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/BaseWorker.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/BaseWorker.java
@@ -209,4 +209,8 @@ public abstract class BaseWorker implements IWorker {
         }
         return type;
     }
+
+    public boolean requiresTransaction(final IServices services) {
+        return false;
+    }
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/IWorker.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/IWorker.java
@@ -20,10 +20,10 @@ import org.signserver.common.WorkerType;
 
 /**
  * IWorker is an interface that all signers and services should implement.
- *
+ * 
  * There exists a BaseWorker that can be extended covering some of it's 
  * functions.
- *
+ * 
  * @author Philip Vendil
  * @version $Id$
  */
@@ -40,7 +40,7 @@ public interface IWorker {
      * @return The suggested worker type describing this implementation
      */
     WorkerType getWorkerType();
-
+    
     /**
      * Initialization method that should be called directly after creation.
      * @param workerId the unique id of the worker
@@ -50,12 +50,12 @@ public interface IWorker {
      * implementation and MailSignerContext for mail processors.
      */
     void init(int workerId, WorkerConfig config, WorkerContext workerContext, EntityManager workerEntityManager);
-
+    
     /**
      * @return The worker configuration
      */
     WorkerConfig getConfig();
-
+    
     /**
      * Should return the actual status of the worker, status could be if
      * the signer is activated or not, or equivalent for a service.
@@ -63,16 +63,9 @@ public interface IWorker {
      * for instance by the WorkerSessionBean and that would not be discovered 
      * by the worker it self. Example are errors in the configuration of an 
      * IAuthorizer.
-     *
+     * 
      * @param services services for the implementations to use
      * @return a WorkerStatus object.
      */
     WorkerStatusInfo getStatus(final List<String> additionalFatalErrors, final IServices services);
-
-    /**
-     * If worker requires a database transaction when using this crypto token.
-     *
-     * @return True or false
-     */
-    boolean requiresTransaction(final IServices services);
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/IWorker.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/IWorker.java
@@ -20,10 +20,10 @@ import org.signserver.common.WorkerType;
 
 /**
  * IWorker is an interface that all signers and services should implement.
- * 
+ *
  * There exists a BaseWorker that can be extended covering some of it's 
  * functions.
- * 
+ *
  * @author Philip Vendil
  * @version $Id$
  */
@@ -40,7 +40,7 @@ public interface IWorker {
      * @return The suggested worker type describing this implementation
      */
     WorkerType getWorkerType();
-    
+
     /**
      * Initialization method that should be called directly after creation.
      * @param workerId the unique id of the worker
@@ -50,12 +50,12 @@ public interface IWorker {
      * implementation and MailSignerContext for mail processors.
      */
     void init(int workerId, WorkerConfig config, WorkerContext workerContext, EntityManager workerEntityManager);
-    
+
     /**
      * @return The worker configuration
      */
     WorkerConfig getConfig();
-    
+
     /**
      * Should return the actual status of the worker, status could be if
      * the signer is activated or not, or equivalent for a service.
@@ -63,9 +63,16 @@ public interface IWorker {
      * for instance by the WorkerSessionBean and that would not be discovered 
      * by the worker it self. Example are errors in the configuration of an 
      * IAuthorizer.
-     * 
+     *
      * @param services services for the implementations to use
      * @return a WorkerStatus object.
      */
     WorkerStatusInfo getStatus(final List<String> additionalFatalErrors, final IServices services);
+
+    /**
+     * If worker requires a database transaction when using this crypto token.
+     *
+     * @return True or false
+     */
+    boolean requiresTransaction(final IServices services);
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/IWorker.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/IWorker.java
@@ -68,4 +68,11 @@ public interface IWorker {
      * @return a WorkerStatus object.
      */
     WorkerStatusInfo getStatus(final List<String> additionalFatalErrors, final IServices services);
+
+    /**
+     * If worker requires a database transaction when using this crypto token.
+     *
+     * @return True or false
+     */
+    boolean requiresTransaction(final IServices services);
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/UnloadableWorker.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/UnloadableWorker.java
@@ -38,7 +38,7 @@ import org.signserver.server.timedservices.ITimedService;
  * @version $Id$
  */
 public class UnloadableWorker extends BaseSigner implements ITimedService {
-    
+
     /** Logger for this class. */
     private static final Logger LOG = Logger.getLogger(UnloadableWorker.class);
 
@@ -62,7 +62,7 @@ public class UnloadableWorker extends BaseSigner implements ITimedService {
     @Override
     public WorkerStatusInfo getStatus(List<String> additionalFatalErrors, final IServices services) {
         WorkerStatusInfo status = super.getStatus(additionalFatalErrors, services);
-        
+
         status.setWorkerType(WORKER_TYPE);
 
         return status;
@@ -70,7 +70,7 @@ public class UnloadableWorker extends BaseSigner implements ITimedService {
 
     /**
      * Get the fatal errors for this worker.
-     * 
+     *
      * @return List of errors which for this implementation always will contain
      * an error message
      */
@@ -98,14 +98,14 @@ public class UnloadableWorker extends BaseSigner implements ITimedService {
 
     /**
      * Receives timed service requests but only logs an error.
-     * @throws ServiceExecutionFailedException 
+     * @throws ServiceExecutionFailedException
      */
     @Override
     public void work(final ServiceContext context) throws ServiceExecutionFailedException {
         LOG.error("Service is misconfigured");
     }
 
-    /** 
+    /**
      * @return Always DONT_EXECUTE
      */
     @Override
@@ -126,6 +126,11 @@ public class UnloadableWorker extends BaseSigner implements ITimedService {
      */
     @Override
     public boolean isSingleton() {
+        return false;
+    }
+
+    @Override
+    public boolean requiresTransaction(final IServices services) {
         return false;
     }
 

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/UnloadableWorker.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/UnloadableWorker.java
@@ -130,6 +130,14 @@ public class UnloadableWorker extends BaseSigner implements ITimedService {
     }
 
     /**
+     * @return Always false
+     */
+    @Override
+    public boolean requiresTransaction(final IServices services) {
+        return false;
+    }
+
+    /**
      * @return No log types
      */
     @Override

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/UnloadableWorker.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/UnloadableWorker.java
@@ -38,7 +38,7 @@ import org.signserver.server.timedservices.ITimedService;
  * @version $Id$
  */
 public class UnloadableWorker extends BaseSigner implements ITimedService {
-
+    
     /** Logger for this class. */
     private static final Logger LOG = Logger.getLogger(UnloadableWorker.class);
 
@@ -62,7 +62,7 @@ public class UnloadableWorker extends BaseSigner implements ITimedService {
     @Override
     public WorkerStatusInfo getStatus(List<String> additionalFatalErrors, final IServices services) {
         WorkerStatusInfo status = super.getStatus(additionalFatalErrors, services);
-
+        
         status.setWorkerType(WORKER_TYPE);
 
         return status;
@@ -70,7 +70,7 @@ public class UnloadableWorker extends BaseSigner implements ITimedService {
 
     /**
      * Get the fatal errors for this worker.
-     *
+     * 
      * @return List of errors which for this implementation always will contain
      * an error message
      */
@@ -98,14 +98,14 @@ public class UnloadableWorker extends BaseSigner implements ITimedService {
 
     /**
      * Receives timed service requests but only logs an error.
-     * @throws ServiceExecutionFailedException
+     * @throws ServiceExecutionFailedException 
      */
     @Override
     public void work(final ServiceContext context) throws ServiceExecutionFailedException {
         LOG.error("Service is misconfigured");
     }
 
-    /**
+    /** 
      * @return Always DONT_EXECUTE
      */
     @Override
@@ -126,11 +126,6 @@ public class UnloadableWorker extends BaseSigner implements ITimedService {
      */
     @Override
     public boolean isSingleton() {
-        return false;
-    }
-
-    @Override
-    public boolean requiresTransaction(final IServices services) {
         return false;
     }
 

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/BaseCryptoToken.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/BaseCryptoToken.java
@@ -11,6 +11,7 @@
  *                                                                       *
  *************************************************************************/
 package org.signserver.server.cryptotokens;
+import org.signserver.server.IServices;
 
 /**
  * Base class for crypto tokens.
@@ -24,6 +25,11 @@ public abstract class BaseCryptoToken implements ICryptoTokenV4 {
 
     @Override
     public boolean isNoCertificatesRequired() {
+        return false;
+    }
+
+    @Override
+    public boolean requiresTransactionForSigning() {
         return false;
     }
 

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/BaseCryptoToken.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/BaseCryptoToken.java
@@ -27,4 +27,9 @@ public abstract class BaseCryptoToken implements ICryptoTokenV4 {
         return false;
     }
 
+    @Override
+    public boolean requiresTransactionForSigning() {
+        return false;
+    }
+
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/BaseCryptoToken.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/BaseCryptoToken.java
@@ -11,7 +11,6 @@
  *                                                                       *
  *************************************************************************/
 package org.signserver.server.cryptotokens;
-import org.signserver.server.IServices;
 
 /**
  * Base class for crypto tokens.
@@ -25,11 +24,6 @@ public abstract class BaseCryptoToken implements ICryptoTokenV4 {
 
     @Override
     public boolean isNoCertificatesRequired() {
-        return false;
-    }
-
-    @Override
-    public boolean requiresTransactionForSigning() {
         return false;
     }
 

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/ICryptoTokenV4.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/ICryptoTokenV4.java
@@ -279,4 +279,11 @@ public interface ICryptoTokenV4 {
      * @return True or false
      */
     boolean isNoCertificatesRequired();
+
+    /**
+     * If worker requires a database transaction for signing operation.
+     *
+     * @return True or false
+     */
+    boolean requiresTransactionForSigning();
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/ICryptoTokenV4.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/ICryptoTokenV4.java
@@ -42,42 +42,42 @@ import org.signserver.server.IServices;
  * Forth version of the crypto token interface.
  *
  * Merging: V2, V3, KeyGenerator and KeyRemover
- *
+ * 
  * @author Marcus Lundblad
  * @author Markus Kilås
  * @version $Id$
  */
 public interface ICryptoTokenV4 {
-
+    
     int PURPOSE_SIGN = 1;
-
+    
     int PURPOSE_DECRYPT = 2;
-
-    /**
+    
+    /** 
      * Indicating the next key. Property: "nextCertSignKey".
      * @see org.ejbca.core.model.SecConst#CAKEYPURPOSE_CERTSIGN_NEXT
      */
     int PURPOSE_NEXTKEY = 7;
-
+    
     int PROVIDERUSAGE_SIGN = 1;
-
+    
     int PROVIDERUSAGE_DECRYPT = 2;
-
+    
     /** Crypto token parameter with value of type Boolean telling if the crypto instance should be cached or not. */
     String PARAM_CACHEPRIVATEKEY = "CACHEPRIVATEKEY";
-
+    
     /** Crypto token parameter with the value of type Map&lt;String, Object&gt; containing a cache local to this worker instance but possible shared among multiple threads. */
     String PARAM_WORKERCACHE = "WORKERCACHE";
-
+    
     String ALL_KEYS = "all";
-
+    
     String PARAM_INCLUDE_DUMMYCERTIFICATE = "INCLUDE_DUMMYCERTIFICATE";
 
     void init(int workerId, Properties props, IServices services) throws CryptoTokenInitializationFailureException;
 
     /**
      * Method used to activate SignTokens when connected after being off-line.
-     *
+     * 
      * @param authenticationcode used to unlock crypto token, i.e PIN for smartcard HSMs
      * @param services services for implementations to use
      * @throws CryptoTokenOfflineException if SignToken is not available or connected.
@@ -88,7 +88,7 @@ public interface ICryptoTokenV4 {
     /**
      * Method used to deactivate crypto tokens. 
      * Used to set a crypto token too off-line status and to reset the HSMs authorization code.
-     *
+     * 
      * @param services services for implementations to use
      * @return true if deactivation was successful.
      * @throws CryptoTokenOfflineException
@@ -117,15 +117,15 @@ public interface ICryptoTokenV4 {
 
     /**
      * Get token status.
-     *
+     * 
      * @param services Services for implementations to use
      * @return The current state of the crypto token
      */
     int getCryptoTokenStatus(IServices services);
-
+    
     /**
      * Import certificate chain to a crypto token.
-     *
+     * 
      * @param certChain Certificate chain to import, should contain signing certificate
      * @param alias Key alias to import certificate chain in
      * @param athenticationCode Alias-specific authentication code. If this is null
@@ -139,14 +139,14 @@ public interface ICryptoTokenV4 {
      * @throws UnsupportedCryptoTokenParameter In case the supplied crypto token parameter was not known or supported by the token
      */
     void importCertificateChain(List<Certificate> certChain, String alias,
-                                char[] athenticationCode, Map<String, Object> params,
-                                IServices services) throws
+            char[] athenticationCode, Map<String, Object> params,
+            IServices services) throws 
             TokenOutOfSpaceException,
             CryptoTokenOfflineException,
             NoSuchAliasException,
             InvalidAlgorithmParameterException,
             UnsupportedCryptoTokenParameter;
-
+    
     /**
      * Queries the entries in the token.
      * @param startIndex Start index of first result (0-based)
@@ -166,14 +166,14 @@ public interface ICryptoTokenV4 {
             QueryException,
             InvalidAlgorithmParameterException,
             UnsupportedCryptoTokenParameter;
-
+    
     /**
      * Acquire a crypto instance in order to perform crypto operations during
      * a limited scope.
-     *
+     * 
      * It is the caller's responsibility to make sure the call is followed up
      * by a call to releaseCryptoInstance() for each instance. Use try-final.
-     *
+     * 
      * @param alias of the entry in the CryptoToken to quire an crypto instance for
      * @param params Additional parameters to pass to the crypto token
      * @param context the request context
@@ -186,11 +186,11 @@ public interface ICryptoTokenV4 {
      * @throws SignServerException For other internal (not to be leaked to the client side) errors
      */
     ICryptoInstance acquireCryptoInstance(String alias, Map<String, Object> params, RequestContext context) throws
-            CryptoTokenOfflineException,
-            NoSuchAliasException,
+            CryptoTokenOfflineException, 
+            NoSuchAliasException, 
             InvalidAlgorithmParameterException,
             UnsupportedCryptoTokenParameter,
-            IllegalRequestException,
+            IllegalRequestException, 
             SignServerException;
 
     /**
@@ -204,8 +204,8 @@ public interface ICryptoTokenV4 {
      * @throws CryptoTokenOfflineException In case the token was not active or could not function for any other reasons
      * @throws IllegalArgumentException
      */
-
-
+    
+    
     /**
      * Generate a new key.
      * @param keyAlgorithm Key algorithm
@@ -222,10 +222,10 @@ public interface ICryptoTokenV4 {
      * @throws UnsupportedCryptoTokenParameter If one or more crypto token parameters was unknown or not supported by the token implementation
      */
     void generateKey(String keyAlgorithm, String keySpec, String alias,
-                     char[] authCode, Map<String, Object> params, IServices services) throws
+            char[] authCode, Map<String, Object> params, IServices services) throws
             TokenOutOfSpaceException,
             CryptoTokenOfflineException,
-            DuplicateAliasException,
+            DuplicateAliasException, 
             NoSuchAlgorithmException,
             InvalidAlgorithmParameterException,
             UnsupportedCryptoTokenParameter;
@@ -241,7 +241,7 @@ public interface ICryptoTokenV4 {
      * @throws NoSuchAliasException In case the alias did not exist in the token
      */
     ICertReqData genCertificateRequest(ISignerCertReqInfo info,
-                                       boolean explicitEccParameters, String keyAlias, IServices services)
+            boolean explicitEccParameters, String keyAlias, IServices services)
             throws
             CryptoTokenOfflineException,
             NoSuchAliasException;
@@ -256,10 +256,10 @@ public interface ICryptoTokenV4 {
      * @throws KeyStoreException In case of error accessing the key
      */
     Collection<KeyTestResult> testKey(String alias,
-                                      char[] authCode,
-                                      IServices Services)
+            char[] authCode,
+            IServices Services)
             throws CryptoTokenOfflineException, KeyStoreException;
-
+    
     /**
      * Remove a key from the token (if supported).
      *
@@ -270,20 +270,13 @@ public interface ICryptoTokenV4 {
      * @throws KeyStoreException for keystore related errors
      * @throws SignServerException if the keystore did not contain a key with the specified alias
      */
-    boolean removeKey(String alias, IServices services) throws CryptoTokenOfflineException,
+    boolean removeKey(String alias, IServices services) throws CryptoTokenOfflineException, 
             KeyStoreException, SignServerException;
-
+    
     /**
      * If signer requires no certificates when using this crypto token.
      *
      * @return True or false
      */
     boolean isNoCertificatesRequired();
-
-    /**
-     * If worker requires a database transaction for signing operation.
-     *
-     * @return True or false
-     */
-    boolean requiresTransactionForSigning();
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/ICryptoTokenV4.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/ICryptoTokenV4.java
@@ -42,42 +42,42 @@ import org.signserver.server.IServices;
  * Forth version of the crypto token interface.
  *
  * Merging: V2, V3, KeyGenerator and KeyRemover
- * 
+ *
  * @author Marcus Lundblad
  * @author Markus Kilås
  * @version $Id$
  */
 public interface ICryptoTokenV4 {
-    
+
     int PURPOSE_SIGN = 1;
-    
+
     int PURPOSE_DECRYPT = 2;
-    
-    /** 
+
+    /**
      * Indicating the next key. Property: "nextCertSignKey".
      * @see org.ejbca.core.model.SecConst#CAKEYPURPOSE_CERTSIGN_NEXT
      */
     int PURPOSE_NEXTKEY = 7;
-    
+
     int PROVIDERUSAGE_SIGN = 1;
-    
+
     int PROVIDERUSAGE_DECRYPT = 2;
-    
+
     /** Crypto token parameter with value of type Boolean telling if the crypto instance should be cached or not. */
     String PARAM_CACHEPRIVATEKEY = "CACHEPRIVATEKEY";
-    
+
     /** Crypto token parameter with the value of type Map&lt;String, Object&gt; containing a cache local to this worker instance but possible shared among multiple threads. */
     String PARAM_WORKERCACHE = "WORKERCACHE";
-    
+
     String ALL_KEYS = "all";
-    
+
     String PARAM_INCLUDE_DUMMYCERTIFICATE = "INCLUDE_DUMMYCERTIFICATE";
 
     void init(int workerId, Properties props, IServices services) throws CryptoTokenInitializationFailureException;
 
     /**
      * Method used to activate SignTokens when connected after being off-line.
-     * 
+     *
      * @param authenticationcode used to unlock crypto token, i.e PIN for smartcard HSMs
      * @param services services for implementations to use
      * @throws CryptoTokenOfflineException if SignToken is not available or connected.
@@ -88,7 +88,7 @@ public interface ICryptoTokenV4 {
     /**
      * Method used to deactivate crypto tokens. 
      * Used to set a crypto token too off-line status and to reset the HSMs authorization code.
-     * 
+     *
      * @param services services for implementations to use
      * @return true if deactivation was successful.
      * @throws CryptoTokenOfflineException
@@ -117,15 +117,15 @@ public interface ICryptoTokenV4 {
 
     /**
      * Get token status.
-     * 
+     *
      * @param services Services for implementations to use
      * @return The current state of the crypto token
      */
     int getCryptoTokenStatus(IServices services);
-    
+
     /**
      * Import certificate chain to a crypto token.
-     * 
+     *
      * @param certChain Certificate chain to import, should contain signing certificate
      * @param alias Key alias to import certificate chain in
      * @param athenticationCode Alias-specific authentication code. If this is null
@@ -139,14 +139,14 @@ public interface ICryptoTokenV4 {
      * @throws UnsupportedCryptoTokenParameter In case the supplied crypto token parameter was not known or supported by the token
      */
     void importCertificateChain(List<Certificate> certChain, String alias,
-            char[] athenticationCode, Map<String, Object> params,
-            IServices services) throws 
+                                char[] athenticationCode, Map<String, Object> params,
+                                IServices services) throws
             TokenOutOfSpaceException,
             CryptoTokenOfflineException,
             NoSuchAliasException,
             InvalidAlgorithmParameterException,
             UnsupportedCryptoTokenParameter;
-    
+
     /**
      * Queries the entries in the token.
      * @param startIndex Start index of first result (0-based)
@@ -166,14 +166,14 @@ public interface ICryptoTokenV4 {
             QueryException,
             InvalidAlgorithmParameterException,
             UnsupportedCryptoTokenParameter;
-    
+
     /**
      * Acquire a crypto instance in order to perform crypto operations during
      * a limited scope.
-     * 
+     *
      * It is the caller's responsibility to make sure the call is followed up
      * by a call to releaseCryptoInstance() for each instance. Use try-final.
-     * 
+     *
      * @param alias of the entry in the CryptoToken to quire an crypto instance for
      * @param params Additional parameters to pass to the crypto token
      * @param context the request context
@@ -186,11 +186,11 @@ public interface ICryptoTokenV4 {
      * @throws SignServerException For other internal (not to be leaked to the client side) errors
      */
     ICryptoInstance acquireCryptoInstance(String alias, Map<String, Object> params, RequestContext context) throws
-            CryptoTokenOfflineException, 
-            NoSuchAliasException, 
+            CryptoTokenOfflineException,
+            NoSuchAliasException,
             InvalidAlgorithmParameterException,
             UnsupportedCryptoTokenParameter,
-            IllegalRequestException, 
+            IllegalRequestException,
             SignServerException;
 
     /**
@@ -204,8 +204,8 @@ public interface ICryptoTokenV4 {
      * @throws CryptoTokenOfflineException In case the token was not active or could not function for any other reasons
      * @throws IllegalArgumentException
      */
-    
-    
+
+
     /**
      * Generate a new key.
      * @param keyAlgorithm Key algorithm
@@ -222,10 +222,10 @@ public interface ICryptoTokenV4 {
      * @throws UnsupportedCryptoTokenParameter If one or more crypto token parameters was unknown or not supported by the token implementation
      */
     void generateKey(String keyAlgorithm, String keySpec, String alias,
-            char[] authCode, Map<String, Object> params, IServices services) throws
+                     char[] authCode, Map<String, Object> params, IServices services) throws
             TokenOutOfSpaceException,
             CryptoTokenOfflineException,
-            DuplicateAliasException, 
+            DuplicateAliasException,
             NoSuchAlgorithmException,
             InvalidAlgorithmParameterException,
             UnsupportedCryptoTokenParameter;
@@ -241,7 +241,7 @@ public interface ICryptoTokenV4 {
      * @throws NoSuchAliasException In case the alias did not exist in the token
      */
     ICertReqData genCertificateRequest(ISignerCertReqInfo info,
-            boolean explicitEccParameters, String keyAlias, IServices services)
+                                       boolean explicitEccParameters, String keyAlias, IServices services)
             throws
             CryptoTokenOfflineException,
             NoSuchAliasException;
@@ -256,10 +256,10 @@ public interface ICryptoTokenV4 {
      * @throws KeyStoreException In case of error accessing the key
      */
     Collection<KeyTestResult> testKey(String alias,
-            char[] authCode,
-            IServices Services)
+                                      char[] authCode,
+                                      IServices Services)
             throws CryptoTokenOfflineException, KeyStoreException;
-    
+
     /**
      * Remove a key from the token (if supported).
      *
@@ -270,13 +270,20 @@ public interface ICryptoTokenV4 {
      * @throws KeyStoreException for keystore related errors
      * @throws SignServerException if the keystore did not contain a key with the specified alias
      */
-    boolean removeKey(String alias, IServices services) throws CryptoTokenOfflineException, 
+    boolean removeKey(String alias, IServices services) throws CryptoTokenOfflineException,
             KeyStoreException, SignServerException;
-    
+
     /**
      * If signer requires no certificates when using this crypto token.
      *
      * @return True or false
      */
     boolean isNoCertificatesRequired();
+
+    /**
+     * If worker requires a database transaction for signing operation.
+     *
+     * @return True or false
+     */
+    boolean requiresTransactionForSigning();
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/signers/CryptoWorker.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/signers/CryptoWorker.java
@@ -13,18 +13,21 @@
 package org.signserver.server.signers;
 
 import java.util.List;
+import org.apache.log4j.Logger;
 import org.signserver.common.WorkerStatusInfo;
 import org.signserver.server.IServices;
+import org.signserver.server.cryptotokens.ICryptoTokenV4;
 
 /**
  * Worker not performing any operations on its own.
- * Meant as a placeholder for a crypto token to be referenced from an other 
+ * Meant as a placeholder for a crypto token to be referenced from an other
  * worker.
  * @author Markus Kilås
  * @version $Id$
  */
 public class CryptoWorker extends NullSigner {
 
+    private static final Logger LOG = Logger.getLogger(CryptoWorker.class);
     private static final String WORKER_TYPE = "CryptoWorker";
 
     @Override
@@ -35,9 +38,22 @@ public class CryptoWorker extends NullSigner {
     @Override
     public WorkerStatusInfo getStatus(List<String> additionalFatalErrors, final IServices services) {
         WorkerStatusInfo status = super.getStatus(additionalFatalErrors, services);
-        
+
         status.setWorkerType(WORKER_TYPE);
         return status;
+    }
+
+    public boolean requiresTransaction(final IServices services) {
+        try {
+            ICryptoTokenV4 cryptoToken = super.getCryptoToken(services);
+            if (cryptoToken == null) {
+                return false;
+            }
+            return cryptoToken.requiresTransactionForSigning();
+        } catch (Exception e) {
+            LOG.warn("Unable to determine whether a worker requires a transaction. Defaulting to False.", e);
+            return false;
+        }
     }
 
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/signers/CryptoWorker.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/signers/CryptoWorker.java
@@ -13,8 +13,10 @@
 package org.signserver.server.signers;
 
 import java.util.List;
+import org.apache.log4j.Logger;
 import org.signserver.common.WorkerStatusInfo;
 import org.signserver.server.IServices;
+import org.signserver.server.cryptotokens.ICryptoTokenV4;
 
 /**
  * Worker not performing any operations on its own.
@@ -25,6 +27,7 @@ import org.signserver.server.IServices;
  */
 public class CryptoWorker extends NullSigner {
 
+    private static final Logger LOG = Logger.getLogger(CryptoWorker.class);
     private static final String WORKER_TYPE = "CryptoWorker";
 
     @Override
@@ -38,6 +41,19 @@ public class CryptoWorker extends NullSigner {
         
         status.setWorkerType(WORKER_TYPE);
         return status;
+    }
+
+    public boolean requiresTransaction(final IServices services) {
+        try {
+            ICryptoTokenV4 cryptoToken = super.getCryptoToken(services);
+            if (cryptoToken == null) {
+                return false;
+            }
+            return cryptoToken.requiresTransactionForSigning();
+        } catch (Exception e) {
+            LOG.warn("Unable to determine whether a worker requires a transaction. Defaulting to False.", e);
+            return false;
+        }
     }
 
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/signers/CryptoWorker.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/signers/CryptoWorker.java
@@ -13,21 +13,18 @@
 package org.signserver.server.signers;
 
 import java.util.List;
-import org.apache.log4j.Logger;
 import org.signserver.common.WorkerStatusInfo;
 import org.signserver.server.IServices;
-import org.signserver.server.cryptotokens.ICryptoTokenV4;
 
 /**
  * Worker not performing any operations on its own.
- * Meant as a placeholder for a crypto token to be referenced from an other
+ * Meant as a placeholder for a crypto token to be referenced from an other 
  * worker.
  * @author Markus Kilås
  * @version $Id$
  */
 public class CryptoWorker extends NullSigner {
 
-    private static final Logger LOG = Logger.getLogger(CryptoWorker.class);
     private static final String WORKER_TYPE = "CryptoWorker";
 
     @Override
@@ -38,22 +35,9 @@ public class CryptoWorker extends NullSigner {
     @Override
     public WorkerStatusInfo getStatus(List<String> additionalFatalErrors, final IServices services) {
         WorkerStatusInfo status = super.getStatus(additionalFatalErrors, services);
-
+        
         status.setWorkerType(WORKER_TYPE);
         return status;
-    }
-
-    public boolean requiresTransaction(final IServices services) {
-        try {
-            ICryptoTokenV4 cryptoToken = super.getCryptoToken(services);
-            if (cryptoToken == null) {
-                return false;
-            }
-            return cryptoToken.requiresTransactionForSigning();
-        } catch (Exception e) {
-            LOG.warn("Unable to determine whether a worker requires a transaction. Defaulting to False.", e);
-            return false;
-        }
     }
 
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/BaseTimedService.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/BaseTimedService.java
@@ -143,6 +143,11 @@ public abstract class BaseTimedService extends BaseWorker implements ITimedServi
     }
 
     @Override
+    public boolean requiresTransaction(final IServices services) {
+        return false;
+    }
+
+    @Override
     public WorkerStatusInfo getStatus(final List<String> additionalFatalErrors, final IServices services) {
         final List<String> fatalErrorsIncludingAdditionalErrors = new LinkedList<>(additionalFatalErrors);
         fatalErrorsIncludingAdditionalErrors.addAll(getFatalErrors(services));

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/BaseTimedService.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/BaseTimedService.java
@@ -46,14 +46,14 @@ public abstract class BaseTimedService extends BaseWorker implements ITimedServi
     private final Set<ITimedService.LogType> logTypes =
             EnumSet.noneOf(ITimedService.LogType.class);
     private final List<String> fatalErrors = new LinkedList<>();
-    
+
     protected BaseTimedService() {
     }
 
     @Override
     public void init(int workerId, WorkerConfig config, WorkerContext workerContext, EntityManager workerEM) {
         super.init(workerId, config, workerContext, workerEM);
-        
+
         final String[] logTypeStrings =
                 config.getPropertyThatCouldBeEmpty(ServiceConfig.WORK_LOG_TYPES,
                         ServiceConfig.DEFAULT_WORK_LOG_TYPES).split(",");
@@ -68,8 +68,8 @@ public abstract class BaseTimedService extends BaseWorker implements ITimedServi
             }
         }
     }
-    
-    
+
+
 
     /**
      * @see org.signserver.server.timedservices.ITimedService#getNextInterval()
@@ -77,11 +77,11 @@ public abstract class BaseTimedService extends BaseWorker implements ITimedServi
     @Override
     public long getNextInterval() {
         long retval = DONT_EXECUTE;
-    	final String interval
+        final String interval
                 = config.getProperties().getProperty(ServiceConfig.INTERVAL);
         final String intervalMs
                 = config.getProperties().getProperty(ServiceConfig.INTERVALMS);
-    	final String cronExpression
+        final String cronExpression
                 = config.getProperties().getProperty(ServiceConfig.CRON);
 
         if (interval == null && cronExpression == null && intervalMs == null) {
@@ -143,6 +143,11 @@ public abstract class BaseTimedService extends BaseWorker implements ITimedServi
     }
 
     @Override
+    public boolean requiresTransaction(final IServices services) {
+        return false;
+    }
+
+    @Override
     public WorkerStatusInfo getStatus(final List<String> additionalFatalErrors, final IServices services) {
         final List<String> fatalErrorsIncludingAdditionalErrors = new LinkedList<>(additionalFatalErrors);
         fatalErrorsIncludingAdditionalErrors.addAll(getFatalErrors(services));
@@ -159,17 +164,17 @@ public abstract class BaseTimedService extends BaseWorker implements ITimedServi
         Properties properties = config.getProperties();
         for (String key : properties.stringPropertyNames()) {
             final String value = config.shouldMaskProperty(key) ?
-                                 WorkerConfig.WORKER_PROPERTY_MASK_PLACEHOLDER :
-                                 properties.getProperty(key);
+                    WorkerConfig.WORKER_PROPERTY_MASK_PLACEHOLDER :
+                    properties.getProperty(key);
             configValue.append("  ").append(key).append("=").append(value).append("\n\n");
         }
         completeEntries.add(new WorkerStatusInfo.Entry("Active Properties are", configValue.toString()));
 
         return new WorkerStatusInfo(workerId, config.getProperty("NAME"),
-                                    "Service", WorkerStatus.STATUS_ACTIVE,
-                                    briefEntries,
-                                    fatalErrorsIncludingAdditionalErrors,
-                                    completeEntries, config);
+                "Service", WorkerStatus.STATUS_ACTIVE,
+                briefEntries,
+                fatalErrorsIncludingAdditionalErrors,
+                completeEntries, config);
     }
 
     /**
@@ -189,7 +194,7 @@ public abstract class BaseTimedService extends BaseWorker implements ITimedServi
     @Override
     protected List<String> getFatalErrors(IServices services) {
         final List<String> errors = new LinkedList<>(super.getFatalErrors(services));
-        
+
         errors.addAll(fatalErrors);
         return errors;
     }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/BaseTimedService.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/BaseTimedService.java
@@ -46,14 +46,14 @@ public abstract class BaseTimedService extends BaseWorker implements ITimedServi
     private final Set<ITimedService.LogType> logTypes =
             EnumSet.noneOf(ITimedService.LogType.class);
     private final List<String> fatalErrors = new LinkedList<>();
-
+    
     protected BaseTimedService() {
     }
 
     @Override
     public void init(int workerId, WorkerConfig config, WorkerContext workerContext, EntityManager workerEM) {
         super.init(workerId, config, workerContext, workerEM);
-
+        
         final String[] logTypeStrings =
                 config.getPropertyThatCouldBeEmpty(ServiceConfig.WORK_LOG_TYPES,
                         ServiceConfig.DEFAULT_WORK_LOG_TYPES).split(",");
@@ -68,8 +68,8 @@ public abstract class BaseTimedService extends BaseWorker implements ITimedServi
             }
         }
     }
-
-
+    
+    
 
     /**
      * @see org.signserver.server.timedservices.ITimedService#getNextInterval()
@@ -77,11 +77,11 @@ public abstract class BaseTimedService extends BaseWorker implements ITimedServi
     @Override
     public long getNextInterval() {
         long retval = DONT_EXECUTE;
-        final String interval
+    	final String interval
                 = config.getProperties().getProperty(ServiceConfig.INTERVAL);
         final String intervalMs
                 = config.getProperties().getProperty(ServiceConfig.INTERVALMS);
-        final String cronExpression
+    	final String cronExpression
                 = config.getProperties().getProperty(ServiceConfig.CRON);
 
         if (interval == null && cronExpression == null && intervalMs == null) {
@@ -143,11 +143,6 @@ public abstract class BaseTimedService extends BaseWorker implements ITimedServi
     }
 
     @Override
-    public boolean requiresTransaction(final IServices services) {
-        return false;
-    }
-
-    @Override
     public WorkerStatusInfo getStatus(final List<String> additionalFatalErrors, final IServices services) {
         final List<String> fatalErrorsIncludingAdditionalErrors = new LinkedList<>(additionalFatalErrors);
         fatalErrorsIncludingAdditionalErrors.addAll(getFatalErrors(services));
@@ -164,17 +159,17 @@ public abstract class BaseTimedService extends BaseWorker implements ITimedServi
         Properties properties = config.getProperties();
         for (String key : properties.stringPropertyNames()) {
             final String value = config.shouldMaskProperty(key) ?
-                    WorkerConfig.WORKER_PROPERTY_MASK_PLACEHOLDER :
-                    properties.getProperty(key);
+                                 WorkerConfig.WORKER_PROPERTY_MASK_PLACEHOLDER :
+                                 properties.getProperty(key);
             configValue.append("  ").append(key).append("=").append(value).append("\n\n");
         }
         completeEntries.add(new WorkerStatusInfo.Entry("Active Properties are", configValue.toString()));
 
         return new WorkerStatusInfo(workerId, config.getProperty("NAME"),
-                "Service", WorkerStatus.STATUS_ACTIVE,
-                briefEntries,
-                fatalErrorsIncludingAdditionalErrors,
-                completeEntries, config);
+                                    "Service", WorkerStatus.STATUS_ACTIVE,
+                                    briefEntries,
+                                    fatalErrorsIncludingAdditionalErrors,
+                                    completeEntries, config);
     }
 
     /**
@@ -194,7 +189,7 @@ public abstract class BaseTimedService extends BaseWorker implements ITimedServi
     @Override
     protected List<String> getFatalErrors(IServices services) {
         final List<String> errors = new LinkedList<>(super.getFatalErrors(services));
-
+        
         errors.addAll(fatalErrors);
         return errors;
     }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/ITimedService.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/ITimedService.java
@@ -14,13 +14,12 @@ package org.signserver.server.timedservices;
 
 import java.util.Set;
 import org.signserver.common.ServiceContext;
-import org.signserver.server.IServices;
 import org.signserver.server.IWorker;
 import org.signserver.server.ServiceExecutionFailedException;
 
 /**
  * ITimedService is an interface that all services should implement.
- *
+ * 
  * There exists a BaseTimedService that can be extended covering some of it's functions
  *
  * @author Philip Vendil
@@ -37,7 +36,7 @@ public interface ITimedService extends IWorker {
      * Method that should do the actual work and should
      * be implemented by all services. The method is run
      * at a periodical interval defined in getNextInterval.
-     *
+     * 
      * @param context Additional context for the execution
      * @throws ServiceExecutionFailedException if execution of a service failed
      */
@@ -46,9 +45,9 @@ public interface ITimedService extends IWorker {
     /**
      * @return should return the milliseconds to next time the service should
      * execute, or -1 (DONE_EXECUTE) if the service should stop executing.
-     *
-     * IMPORTANT, this have changed since 2.0 version were seconds were
-     * specified. This shouldn't be confused with the INTERVAL setting
+     * 
+     * IMPORTANT, this have changed since 2.0 version were seconds were 
+     * specified. This shouldn't be confused with the INTERVAL setting 
      * that is still configured in seconds.
      */
     long getNextInterval();
@@ -63,19 +62,14 @@ public interface ITimedService extends IWorker {
      * the time, of false if it should be run on all nodes simultaneously.
      */
     boolean isSingleton();
-
-    /**
-     * @return true if the service requires a transaction to be executed successfully
-     */
-    boolean requiresTransaction(final IServices services);
-
+    
     /**
      * Get log types for logging work invocations.
-     *
+     * 
      * @return A list of log types to use
      */
     Set<LogType> getLogTypes();
-
+    
     /**
      * Representation of logging options for logging of service invocations.
      */
@@ -84,7 +78,7 @@ public interface ITimedService extends IWorker {
          * Using CESeCore secure audit logging.
          */
         SECURE_AUDITLOGGING,
-
+        
         /**
          * Using Log4J info logging.
          */

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/ITimedService.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/ITimedService.java
@@ -14,12 +14,13 @@ package org.signserver.server.timedservices;
 
 import java.util.Set;
 import org.signserver.common.ServiceContext;
+import org.signserver.server.IServices;
 import org.signserver.server.IWorker;
 import org.signserver.server.ServiceExecutionFailedException;
 
 /**
  * ITimedService is an interface that all services should implement.
- * 
+ *
  * There exists a BaseTimedService that can be extended covering some of it's functions
  *
  * @author Philip Vendil
@@ -36,7 +37,7 @@ public interface ITimedService extends IWorker {
      * Method that should do the actual work and should
      * be implemented by all services. The method is run
      * at a periodical interval defined in getNextInterval.
-     * 
+     *
      * @param context Additional context for the execution
      * @throws ServiceExecutionFailedException if execution of a service failed
      */
@@ -45,9 +46,9 @@ public interface ITimedService extends IWorker {
     /**
      * @return should return the milliseconds to next time the service should
      * execute, or -1 (DONE_EXECUTE) if the service should stop executing.
-     * 
-     * IMPORTANT, this have changed since 2.0 version were seconds were 
-     * specified. This shouldn't be confused with the INTERVAL setting 
+     *
+     * IMPORTANT, this have changed since 2.0 version were seconds were
+     * specified. This shouldn't be confused with the INTERVAL setting
      * that is still configured in seconds.
      */
     long getNextInterval();
@@ -62,14 +63,19 @@ public interface ITimedService extends IWorker {
      * the time, of false if it should be run on all nodes simultaneously.
      */
     boolean isSingleton();
-    
+
+    /**
+     * @return true if the service requires a transaction to be executed successfully
+     */
+    boolean requiresTransaction(final IServices services);
+
     /**
      * Get log types for logging work invocations.
-     * 
+     *
      * @return A list of log types to use
      */
     Set<LogType> getLogTypes();
-    
+
     /**
      * Representation of logging options for logging of service invocations.
      */
@@ -78,7 +84,7 @@ public interface ITimedService extends IWorker {
          * Using CESeCore secure audit logging.
          */
         SECURE_AUDITLOGGING,
-        
+
         /**
          * Using Log4J info logging.
          */

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/ITimedService.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/ITimedService.java
@@ -14,6 +14,7 @@ package org.signserver.server.timedservices;
 
 import java.util.Set;
 import org.signserver.common.ServiceContext;
+import org.signserver.server.IServices;
 import org.signserver.server.IWorker;
 import org.signserver.server.ServiceExecutionFailedException;
 
@@ -62,6 +63,11 @@ public interface ITimedService extends IWorker {
      * the time, of false if it should be run on all nodes simultaneously.
      */
     boolean isSingleton();
+
+    /**
+     * @return true if the service requires a transaction to be executed successfully
+     */
+    boolean requiresTransaction(final IServices services);
     
     /**
      * Get log types for logging work invocations.

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/DispatcherProcessSessionBean.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/DispatcherProcessSessionBean.java
@@ -135,11 +135,11 @@ public class DispatcherProcessSessionBean implements DispatcherProcessSessionLoc
 
     @Override
     public Response process(final AdminInfo adminInfo, final WorkerIdentifier wi,
-            final Request request, final RequestContext requestContext)
+                            final Request request, final RequestContext requestContext)
             throws IllegalRequestException, CryptoTokenOfflineException,
             SignServerException {
         requestContext.setServices(servicesImpl);
-        if (SessionUtils.needsTransaction(workerManagerSession, wi)) {
+        if (SessionUtils.needsTransaction(workerManagerSession, wi, servicesImpl)) {
             // use separate transaction bean to avoid deadlock
             return dispatcherProcessTransSession.processWithTransaction(adminInfo, wi, request, requestContext);
         } else {

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/DispatcherProcessSessionBean.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/DispatcherProcessSessionBean.java
@@ -135,11 +135,11 @@ public class DispatcherProcessSessionBean implements DispatcherProcessSessionLoc
 
     @Override
     public Response process(final AdminInfo adminInfo, final WorkerIdentifier wi,
-                            final Request request, final RequestContext requestContext)
+            final Request request, final RequestContext requestContext)
             throws IllegalRequestException, CryptoTokenOfflineException,
             SignServerException {
         requestContext.setServices(servicesImpl);
-        if (SessionUtils.needsTransaction(workerManagerSession, wi, servicesImpl)) {
+        if (SessionUtils.needsTransaction(workerManagerSession, wi)) {
             // use separate transaction bean to avoid deadlock
             return dispatcherProcessTransSession.processWithTransaction(adminInfo, wi, request, requestContext);
         } else {

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/DispatcherProcessSessionBean.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/DispatcherProcessSessionBean.java
@@ -139,7 +139,7 @@ public class DispatcherProcessSessionBean implements DispatcherProcessSessionLoc
             throws IllegalRequestException, CryptoTokenOfflineException,
             SignServerException {
         requestContext.setServices(servicesImpl);
-        if (SessionUtils.needsTransaction(workerManagerSession, wi)) {
+        if (SessionUtils.needsTransaction(workerManagerSession, wi, servicesImpl)) {
             // use separate transaction bean to avoid deadlock
             return dispatcherProcessTransSession.processWithTransaction(adminInfo, wi, request, requestContext);
         } else {

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/InternalProcessSessionBean.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/InternalProcessSessionBean.java
@@ -70,13 +70,13 @@ public class InternalProcessSessionBean implements InternalProcessSessionLocal {
 
     @EJB
     private SecurityEventsLoggerSessionLocal logSession;
-
+    
     @EJB
     InternalProcessTransactionSessionLocal internalProcessTransSession;
-
+    
     /** Injected by ejb-jar.xml. */
     EntityManager em;
-
+    
     @Resource
     private SessionContext ctx;
 
@@ -99,7 +99,7 @@ public class InternalProcessSessionBean implements InternalProcessSessionLocal {
         }
         processImpl = new WorkerProcessImpl(em, keyUsageCounterDataService, workerManagerSession, logSession);
         session = ctx.getBusinessObject(InternalProcessSessionLocal.class);
-
+        
         // XXX The lookups will fail on GlassFish V2
         // When we no longer support GFv2 we can refactor this code
         ProcessSessionLocal processSession = null;
@@ -133,16 +133,16 @@ public class InternalProcessSessionBean implements InternalProcessSessionLocal {
 
     @Override
     public Response process(final AdminInfo adminInfo, final WorkerIdentifier wi,
-                            final Request request, final RequestContext requestContext)
+            final Request request, final RequestContext requestContext)
             throws IllegalRequestException, CryptoTokenOfflineException,
             SignServerException {
         requestContext.setServices(servicesImpl);
-        if (SessionUtils.needsTransaction(workerManagerSession, wi, servicesImpl)) {
+        if (SessionUtils.needsTransaction(workerManagerSession, wi)) {
             // use separate transaction bean to avoid deadlock
             return internalProcessTransSession.processWithTransaction(adminInfo, wi, request, requestContext);
         } else {
             return processImpl.process(adminInfo, wi, request, requestContext);
         }
-    }
-
+    }    
+    
 }

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/InternalProcessSessionBean.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/InternalProcessSessionBean.java
@@ -70,13 +70,13 @@ public class InternalProcessSessionBean implements InternalProcessSessionLocal {
 
     @EJB
     private SecurityEventsLoggerSessionLocal logSession;
-    
+
     @EJB
     InternalProcessTransactionSessionLocal internalProcessTransSession;
-    
+
     /** Injected by ejb-jar.xml. */
     EntityManager em;
-    
+
     @Resource
     private SessionContext ctx;
 
@@ -99,7 +99,7 @@ public class InternalProcessSessionBean implements InternalProcessSessionLocal {
         }
         processImpl = new WorkerProcessImpl(em, keyUsageCounterDataService, workerManagerSession, logSession);
         session = ctx.getBusinessObject(InternalProcessSessionLocal.class);
-        
+
         // XXX The lookups will fail on GlassFish V2
         // When we no longer support GFv2 we can refactor this code
         ProcessSessionLocal processSession = null;
@@ -133,16 +133,16 @@ public class InternalProcessSessionBean implements InternalProcessSessionLocal {
 
     @Override
     public Response process(final AdminInfo adminInfo, final WorkerIdentifier wi,
-            final Request request, final RequestContext requestContext)
+                            final Request request, final RequestContext requestContext)
             throws IllegalRequestException, CryptoTokenOfflineException,
             SignServerException {
         requestContext.setServices(servicesImpl);
-        if (SessionUtils.needsTransaction(workerManagerSession, wi)) {
+        if (SessionUtils.needsTransaction(workerManagerSession, wi, servicesImpl)) {
             // use separate transaction bean to avoid deadlock
             return internalProcessTransSession.processWithTransaction(adminInfo, wi, request, requestContext);
         } else {
             return processImpl.process(adminInfo, wi, request, requestContext);
         }
-    }    
-    
+    }
+
 }

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/InternalProcessSessionBean.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/InternalProcessSessionBean.java
@@ -137,7 +137,7 @@ public class InternalProcessSessionBean implements InternalProcessSessionLocal {
             throws IllegalRequestException, CryptoTokenOfflineException,
             SignServerException {
         requestContext.setServices(servicesImpl);
-        if (SessionUtils.needsTransaction(workerManagerSession, wi)) {
+        if (SessionUtils.needsTransaction(workerManagerSession, wi, servicesImpl)) {
             // use separate transaction bean to avoid deadlock
             return internalProcessTransSession.processWithTransaction(adminInfo, wi, request, requestContext);
         } else {

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/ProcessSessionBean.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/ProcessSessionBean.java
@@ -335,8 +335,8 @@ public class ProcessSessionBean implements ProcessSessionRemote, ProcessSessionL
         if (LOG.isDebugEnabled()) {
             LOG.debug(">process: " + wi);
         }
-        
-        if (SessionUtils.needsTransaction(workerManagerSession, wi)) {
+
+        if (SessionUtils.needsTransaction(workerManagerSession, wi, servicesImpl)) {
             // use separate transaction bean to avoid deadlock
             return processTransSession.processWithTransaction(adminInfo, wi, request, requestContext);
         } else {

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/ProcessSessionBean.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/ProcessSessionBean.java
@@ -96,24 +96,24 @@ public class ProcessSessionBean implements ProcessSessionRemote, ProcessSessionL
 
     /** Log4j instance for this class. */
     private static final Logger LOG = Logger.getLogger(WorkerSessionBean.class);
-    
+
     private IKeyUsageCounterDataService keyUsageCounterDataService;
 
     @EJB
     private GlobalConfigurationSessionLocal globalConfigurationSession;
-    
+
     @EJB
     private WorkerManagerSingletonBean workerManagerSession;
-    
+
     @EJB
     private SecurityEventsLoggerSessionLocal logSession;
-    
+
     @EJB
     ProcessTransactionSessionLocal processTransSession;
-    
+
     @Resource
     private SessionContext ctx;
-    
+
     EntityManager em;
 
     private WorkerProcessImpl processImpl;
@@ -139,7 +139,7 @@ public class ProcessSessionBean implements ProcessSessionRemote, ProcessSessionL
         processImpl = new WorkerProcessImpl(em, keyUsageCounterDataService, workerManagerSession, logSession);
 
         session = ctx.getBusinessObject(ProcessSessionLocal.class);
-        
+
         // XXX The lookups will fail on GlassFish V2
         // When we no longer support GFv2 we can refactor this code
         InternalProcessSessionLocal internalSession = null;
@@ -170,20 +170,20 @@ public class ProcessSessionBean implements ProcessSessionRemote, ProcessSessionL
             }
         }
     }
-    
+
     // Note: This is the remote interface
     @Override
     public ProcessResponse process(final WorkerIdentifier wi,
-            final ProcessRequest request, final RemoteRequestContext remoteContext)
+                                   final ProcessRequest request, final RemoteRequestContext remoteContext)
             throws IllegalRequestException, CryptoTokenOfflineException,
             SignServerException {
-        
+
         // XXX This is somewhat duplicated in SignSeverWS and other places
         CloseableReadableData requestData = null;
         CloseableWritableData responseData = null;
         try {
             final Request req2;
-            
+
             // Use the new request types with large file support for
             // GenericSignRequest and GenericValidationRequest
             if (request instanceof GenericSignRequest) {
@@ -214,10 +214,10 @@ public class ProcessSessionBean implements ProcessSessionRemote, ProcessSessionL
                 req2 = new SODRequest(sod.getRequestID(), sod.getDataGroupHashes(), sod.getLdsVersion(), sod.getUnicodeVersion(), responseData);
             } else if (request instanceof GenericPropertiesRequest) {
                 GenericPropertiesRequest prop = (GenericPropertiesRequest) request;
-                
+
                 try (ByteArrayOutputStream bout = new ByteArrayOutputStream()) {
                     prop.getProperties().store(bout, null);
-                
+
                     // Upload handling
                     UploadConfig uploadConfig = UploadConfig.create(globalConfigurationSession);
                     requestData = dataFactory.createReadableData(bout.toByteArray(), uploadConfig.getMaxUploadSize(), uploadConfig.getRepository());
@@ -231,10 +231,10 @@ public class ProcessSessionBean implements ProcessSessionRemote, ProcessSessionL
                 // Passthrough for all legacy requests
                 req2 = new LegacyRequest(request);
             }
-            
+
             ProcessResponse result;
             Response response = process(wi, req2, remoteContext, servicesImpl);
-            
+
             if (response instanceof SODResponse) {
                 SODResponse sigResp = (SODResponse) response;
                 result = new SODSignResponse(sigResp.getRequestID(), responseData.toReadableData().getAsByteArray(), sigResp.getSignerCertificate(), sigResp.getArchiveId(), sigResp.getArchivables());
@@ -260,12 +260,12 @@ public class ProcessSessionBean implements ProcessSessionRemote, ProcessSessionL
                 result = new GenericValidationResponse(docResp.getRequestID(), docResp.isValid(), cvr == null ? null : new ValidateResponse(cvr.getValidation(), cvr.getValidCertificatePurposes()));
             } else if (response instanceof CertificateValidationResponse) {
                 CertificateValidationResponse certResp = (CertificateValidationResponse) response;
-                
+
                 result = new ValidateResponse(certResp.getValidation(), certResp.getValidCertificatePurposes());
             } else {
                 throw new SignServerException("Unexpected response type: " + response);
             }
-            
+
             return result;
 
         } catch (FileUploadBase.SizeLimitExceededException ex) {
@@ -295,7 +295,7 @@ public class ProcessSessionBean implements ProcessSessionRemote, ProcessSessionL
             }
         }
     }
-    
+
     private Response process(WorkerIdentifier wi, Request request, RemoteRequestContext remoteContext, AllServicesImpl servicesImpl) throws IllegalRequestException, CryptoTokenOfflineException, SignServerException {
         // Create a new RequestContext at server-side
         final RequestContext requestContext = new RequestContext(true);
@@ -314,7 +314,7 @@ public class ProcessSessionBean implements ProcessSessionRemote, ProcessSessionL
                 requestContext.put(RequestContext.CLIENT_CREDENTIAL_PASSWORD, credential);
             }
         }
-        
+
         // Put transaction ID
         requestContext.put(RequestContext.TRANSACTION_ID, UUID.randomUUID().toString());
 
@@ -322,26 +322,26 @@ public class ProcessSessionBean implements ProcessSessionRemote, ProcessSessionL
         requestContext.setServices(servicesImpl);
         return process(new AdminInfo("Client user", null, null), wi, request, requestContext);
     }
-    
-    
-    
-    
+
+
+
+
     @Override
     public Response process(final AdminInfo adminInfo, final WorkerIdentifier wi,
-            final Request request, final RequestContext requestContext)
+                            final Request request, final RequestContext requestContext)
             throws IllegalRequestException, CryptoTokenOfflineException,
             SignServerException {
         requestContext.setServices(servicesImpl);
         if (LOG.isDebugEnabled()) {
             LOG.debug(">process: " + wi);
         }
-        
-        if (SessionUtils.needsTransaction(workerManagerSession, wi)) {
+
+        if (SessionUtils.needsTransaction(workerManagerSession, wi, servicesImpl)) {
             // use separate transaction bean to avoid deadlock
             return processTransSession.processWithTransaction(adminInfo, wi, request, requestContext);
         } else {
             return processImpl.process(adminInfo, wi, request, requestContext);
         }
-    }        
-    
+    }
+
 }

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/ServiceTimerSessionBean.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/ServiceTimerSessionBean.java
@@ -60,26 +60,26 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
 
     /** Logger for this class. */
     private static final Logger LOG = Logger.getLogger(ServiceTimerSessionBean.class);
-    
+
     @Resource
     private SessionContext sessionCtx;
-    
+
     private IKeyUsageCounterDataService keyUsageCounterDataService;
-    
+
     @EJB
     private GlobalConfigurationSessionLocal globalConfigurationSession;
-    
+
     @EJB
     private WorkerManagerSingletonBean workerManagerSession;
-    
+
     @EJB
     private SecurityEventsLoggerSessionLocal logSession;
 
     /** Injected by ejb-jar.xml. */
     EntityManager em;
-    
+
     private final AllServicesImpl servicesImpl = new AllServicesImpl();
-    
+
     /**
      * Constant indicating the Id of the "service loader" service.
      * Used in a clustered environment to periodically load available
@@ -87,7 +87,7 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
      */
     private static final Integer SERVICELOADER_ID = 0;
     private static final long SERVICELOADER_PERIOD = 5 * 60 * 1000;
-    
+
     // Don't persist the timer
     private static final TimerConfig SERVICELOADER_CONFIG = new TimerConfig(SERVICELOADER_ID, false);
 
@@ -107,7 +107,7 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
             }
             keyUsageCounterDataService = new KeyUsageCounterDataService(em);
         }
-        
+
         // XXX The lookups will fail on GlassFish V2
         // When we no longer support GFv2 we can refactor this code
         InternalProcessSessionLocal internalSession = null;
@@ -138,11 +138,11 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
             }
         }
     }
-    
+
     /**
      * Method implemented from the TimerObject and is the main method of this
      * session bean. It calls the work object for each object.
-     * 
+     *
      * @param timer
      */
     @Timeout
@@ -160,6 +160,7 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
             ITimedService timedService = null;
             boolean run = false;
             boolean isSingleton = false;
+            boolean requiresTransaction = false;
             UserTransaction ut = sessionCtx.getUserTransaction();
             try {
                 ut.begin();
@@ -168,6 +169,7 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
                 timedService = (ITimedService) worker;
                 sessionCtx.getTimerService().createSingleActionTimer(timedService.getNextInterval(), new TimerConfig(timerInfo, false));
                 isSingleton = timedService.isSingleton();
+                requiresTransaction = timedService.requiresTransaction(servicesImpl);
                 if (!isSingleton) {
                     run = true;
                 } else {
@@ -195,11 +197,17 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
                 }
             }
 
+            ut = sessionCtx.getUserTransaction();
             if (run) {
                 if (serviceConfig != null && timedService != null) {
                     try {
                         if (timedService.isActive() && timedService.getNextInterval() != ITimedService.DONT_EXECUTE) {
-                            timedService.work(new ServiceContext(servicesImpl));
+                            if(requiresTransaction) {
+                                ut.begin();
+                                timedService.work(new ServiceContext(servicesImpl));
+                                ut.commit();
+                            }
+
                             serviceConfig.setLastRunTimestamp(new Date());
                             for (final ITimedService.LogType logType :
                                     timedService.getLogTypes()) {
@@ -223,13 +231,14 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
                                         LOG.warn("Unknown log type: " + logType);
                                 }
                             }
-                            
+
                         }
-                    } catch (ServiceExecutionFailedException e) {
+                    } catch (ServiceExecutionFailedException | SystemException | HeuristicRollbackException | NotSupportedException |
+                             HeuristicMixedException | RollbackException e) {
                         // always log to error log, regardless of log types
                         // setup for service run logging
                         LOG.error("Service" + timerInfo + " execution failed. ", e);
-                        
+
                         if (timedService.getLogTypes().contains(ITimedService.LogType.SECURE_AUDITLOGGING)) {
                             logSession.log(
                                     SignServerEventTypes.TIMED_SERVICE_RUN,
@@ -239,6 +248,11 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
                                     "Service invocation", null, null,
                                     timerInfo.toString(),
                                     Collections.<String, Object>singletonMap("Message", e.getMessage()));
+                        }
+                        try {
+                            ut.rollback();
+                        } catch (SystemException ex) {
+                            LOG.error("Rollback failed.", e);
                         }
                     } catch (RuntimeException e) {
                         /*
@@ -251,6 +265,11 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
                          * since it is some kind of catastrophic failure..
                          */
                         LOG.error("Service worker execution failed.", e);
+                        try {
+                            ut.rollback();
+                        } catch (SystemException ex) {
+                            throw new RuntimeException("Rollback failed", ex);
+                        }
                     }
                 } else {
                     LOG.error("Service with ID " + timerInfo + " not found.");
@@ -355,10 +374,10 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
             }
         }
     }
-    
+
     /**
      * Adds a timer to the bean.
-     * 
+     *
      * @param interval Interval of the timer
      * @param id ID of the timer
      */

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/SessionUtils.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/SessionUtils.java
@@ -17,29 +17,32 @@ import org.signserver.common.WorkerIdentifier;
 import org.signserver.ejb.worker.impl.PreloadedWorkerConfig;
 import org.signserver.ejb.worker.impl.WorkerManagerSingletonBean;
 import org.signserver.ejb.worker.impl.WorkerWithComponents;
+import org.signserver.server.IServices;
+import org.signserver.server.IWorker;
 
 /**
  * Utility functions for session beans.
- * 
+ *
  * @author Marcus Lundblad
  * @version $Id$
  */
 public class SessionUtils {
     /**
      * Checks if a process request should be run inside a transaction.
-     * 
+     *
      * @param session
      * @param wi
      * @return true if the request needs a transaction
      */
     public static boolean needsTransaction(final WorkerManagerSingletonBean session,
-                                           final WorkerIdentifier wi) {
+                                           final WorkerIdentifier wi, IServices services) {
         try {
-            final WorkerWithComponents worker = session.getWorkerWithComponents(wi);
-            final PreloadedWorkerConfig pwc = worker.getPreloadedConfig();
+            final WorkerWithComponents workerWithComponents = session.getWorkerWithComponents(wi);
+            final IWorker worker = workerWithComponents.getWorker();
+            final PreloadedWorkerConfig pwc = workerWithComponents.getPreloadedConfig();
 
-            return !worker.getArchivers().isEmpty() ||
-                   !pwc.isDisableKeyUsageCounter() || pwc.isKeyUsageLimitSpecified();
+            return !workerWithComponents.getArchivers().isEmpty() ||
+                    !pwc.isDisableKeyUsageCounter() || pwc.isKeyUsageLimitSpecified() || worker.requiresTransaction(services);
         } catch (NoSuchWorkerException e) {
             return false;
         }

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/SessionUtils.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/SessionUtils.java
@@ -17,32 +17,29 @@ import org.signserver.common.WorkerIdentifier;
 import org.signserver.ejb.worker.impl.PreloadedWorkerConfig;
 import org.signserver.ejb.worker.impl.WorkerManagerSingletonBean;
 import org.signserver.ejb.worker.impl.WorkerWithComponents;
-import org.signserver.server.IServices;
-import org.signserver.server.IWorker;
 
 /**
  * Utility functions for session beans.
- *
+ * 
  * @author Marcus Lundblad
  * @version $Id$
  */
 public class SessionUtils {
     /**
      * Checks if a process request should be run inside a transaction.
-     *
+     * 
      * @param session
      * @param wi
      * @return true if the request needs a transaction
      */
     public static boolean needsTransaction(final WorkerManagerSingletonBean session,
-                                           final WorkerIdentifier wi, IServices services) {
+                                           final WorkerIdentifier wi) {
         try {
-            final WorkerWithComponents workerWithComponents = session.getWorkerWithComponents(wi);
-            final IWorker worker = workerWithComponents.getWorker();
-            final PreloadedWorkerConfig pwc = workerWithComponents.getPreloadedConfig();
+            final WorkerWithComponents worker = session.getWorkerWithComponents(wi);
+            final PreloadedWorkerConfig pwc = worker.getPreloadedConfig();
 
-            return !workerWithComponents.getArchivers().isEmpty() ||
-                    !pwc.isDisableKeyUsageCounter() || pwc.isKeyUsageLimitSpecified() || worker.requiresTransaction(services);
+            return !worker.getArchivers().isEmpty() ||
+                   !pwc.isDisableKeyUsageCounter() || pwc.isKeyUsageLimitSpecified();
         } catch (NoSuchWorkerException e) {
             return false;
         }

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/SessionUtils.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/SessionUtils.java
@@ -17,6 +17,8 @@ import org.signserver.common.WorkerIdentifier;
 import org.signserver.ejb.worker.impl.PreloadedWorkerConfig;
 import org.signserver.ejb.worker.impl.WorkerManagerSingletonBean;
 import org.signserver.ejb.worker.impl.WorkerWithComponents;
+import org.signserver.server.IServices;
+import org.signserver.server.IWorker;
 
 /**
  * Utility functions for session beans.
@@ -33,13 +35,14 @@ public class SessionUtils {
      * @return true if the request needs a transaction
      */
     public static boolean needsTransaction(final WorkerManagerSingletonBean session,
-                                           final WorkerIdentifier wi) {
+                                           final WorkerIdentifier wi, IServices services) {
         try {
-            final WorkerWithComponents worker = session.getWorkerWithComponents(wi);
-            final PreloadedWorkerConfig pwc = worker.getPreloadedConfig();
+            final WorkerWithComponents workerWithComponents = session.getWorkerWithComponents(wi);
+            final IWorker worker = workerWithComponents.getWorker();
+            final PreloadedWorkerConfig pwc = workerWithComponents.getPreloadedConfig();
 
-            return !worker.getArchivers().isEmpty() ||
-                   !pwc.isDisableKeyUsageCounter() || pwc.isKeyUsageLimitSpecified();
+            return !workerWithComponents.getArchivers().isEmpty() ||
+                   !pwc.isDisableKeyUsageCounter() || pwc.isKeyUsageLimitSpecified() || worker.requiresTransaction(services);
         } catch (NoSuchWorkerException e) {
             return false;
         }


### PR DESCRIPTION
Cleanup of the commits from #76

## Describe your changes

<!--- Please describe your changes in detail. Include the motivation for the changes, e.g. what problem it solves or if it fixes a bug. -->


From @3keyroman:

There are use cases, when siging worker needs to be executed in transaction because it interacts with the database. Typically, when the keys are stored in the database, or some other information needs to be updated during signing execution.

This implementation introduces feature to turn on the transaction handling for other use cases then for key usage counter or archiving. Specifically for signing and timed services.

There is a new interface requiresTransaction implemented, which is false by default.



## How has this been tested?

<!--- If relevant, please describe any tests you ran to verify your changes. -->

## Checklist before requesting a review
<!--- To check or uncheck a box, switch between "[x]" and "[ ]" below. -->

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../../CONTRIBUTING.md).
