### PR TITLE
Transaction support for signing and timed service

### DIFF
--- a/signserver/modules/SignServer-Common/src/main/java/org/signserver/common/SignServerConstants.java
+++ b/signserver/modules/SignServer-Common/src/main/java/org/signserver/common/SignServerConstants.java
@@ -89,6 +89,9 @@ public class SignServerConstants {
      */
     public static final String KEYUSAGELIMIT = "KEYUSAGELIMIT";
     public static String DISABLEKEYUSAGECOUNTER = "DISABLEKEYUSAGECOUNTER";
+
+    public static String PROCESSINTRANSACTION = "PROCESSINTRANSACTION";
+
     /**
      * Constant used to set the default value of configuration property to NULL if not setting property means property value is NULL.
      * 

--- a/signserver/modules/SignServer-Server/src/main/java/org/cesecore/keys/token/KeyAliasesCache.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/cesecore/keys/token/KeyAliasesCache.java
@@ -23,12 +23,18 @@ import org.signserver.server.cesecore.internal.CommonCacheBase;
  */
 public class KeyAliasesCache extends CommonCacheBase<PublicKey> {
 
+    long lastUpdate = 0L;
+
     @Override
     public PublicKey getEntry(final Integer id) {
         if (id == null) {
             return null;
         }
         return super.getEntry(id);
+    }
+
+    public void updateCacheTimeStamp() {
+        this.lastUpdate = System.currentTimeMillis();
     }
 
     @Override

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/BaseWorker.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/BaseWorker.java
@@ -209,4 +209,8 @@ public abstract class BaseWorker implements IWorker {
         }
         return type;
     }
+
+    public boolean requiresTransaction(final IServices services) {
+        return false;
+    }
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/IWorker.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/IWorker.java
@@ -68,4 +68,11 @@ public interface IWorker {
      * @return a WorkerStatus object.
      */
     WorkerStatusInfo getStatus(final List<String> additionalFatalErrors, final IServices services);
+
+    /**
+     * If worker requires a database transaction when using this crypto token.
+     *
+     * @return True or false
+     */
+    boolean requiresTransaction(final IServices services);
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/UnloadableWorker.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/UnloadableWorker.java
@@ -129,6 +129,11 @@ public class UnloadableWorker extends BaseSigner implements ITimedService {
         return false;
     }
 
+    @Override
+    public boolean requiresTransaction(final IServices services) {
+        return false;
+    }
+
     /**
      * @return No log types
      */

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/BaseCryptoToken.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/BaseCryptoToken.java
@@ -27,4 +27,9 @@ public abstract class BaseCryptoToken implements ICryptoTokenV4 {
         return false;
     }
 
+    @Override
+    public boolean requiresTransactionForSigning() {
+        return false;
+    }
+
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/ICryptoTokenV4.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cryptotokens/ICryptoTokenV4.java
@@ -279,4 +279,11 @@ public interface ICryptoTokenV4 {
      * @return True or false
      */
     boolean isNoCertificatesRequired();
+
+    /**
+     * If worker requires a database transaction for signing operation.
+     *
+     * @return True or false
+     */
+    boolean requiresTransactionForSigning();
 }

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/signers/BaseSigner.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/signers/BaseSigner.java
@@ -234,6 +234,19 @@ public abstract class BaseSigner extends BaseProcessable implements ISigner {
                                     completeEntries, config);
     }
 
+    public boolean requiresTransaction(final IServices services) {
+        try {
+            ICryptoTokenV4 cryptoToken = super.getCryptoToken(services);
+            if (cryptoToken == null) {
+                return false;
+            }
+            return cryptoToken.requiresTransactionForSigning();
+        } catch (Exception e) {
+            LOG.warn("Unable to determine whether a worker requires a transaction. Defaulting to False.", e);
+            return false;
+        }
+    }
+
     @Override
     protected List<String> getFatalErrors(IServices services) {
         final LinkedList<String> errors = new LinkedList<>(super.getFatalErrors(services));

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/BaseTimedService.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/BaseTimedService.java
@@ -143,6 +143,11 @@ public abstract class BaseTimedService extends BaseWorker implements ITimedServi
     }
 
     @Override
+    public boolean requiresTransaction(final IServices services) {
+        return false;
+    }
+
+    @Override
     public WorkerStatusInfo getStatus(final List<String> additionalFatalErrors, final IServices services) {
         final List<String> fatalErrorsIncludingAdditionalErrors = new LinkedList<>(additionalFatalErrors);
         fatalErrorsIncludingAdditionalErrors.addAll(getFatalErrors(services));

--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/ITimedService.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/timedservices/ITimedService.java
@@ -14,6 +14,7 @@ package org.signserver.server.timedservices;
 
 import java.util.Set;
 import org.signserver.common.ServiceContext;
+import org.signserver.server.IServices;
 import org.signserver.server.IWorker;
 import org.signserver.server.ServiceExecutionFailedException;
 
@@ -62,7 +63,12 @@ public interface ITimedService extends IWorker {
      * the time, of false if it should be run on all nodes simultaneously.
      */
     boolean isSingleton();
-    
+
+    /**
+     * @return true if the service requires a transaction to be executed successfully
+     */
+    boolean requiresTransaction(final IServices services);
+
     /**
      * Get log types for logging work invocations.
      * 

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/DispatcherProcessSessionBean.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/DispatcherProcessSessionBean.java
@@ -139,7 +139,7 @@ public class DispatcherProcessSessionBean implements DispatcherProcessSessionLoc
             throws IllegalRequestException, CryptoTokenOfflineException,
             SignServerException {
         requestContext.setServices(servicesImpl);
-        if (SessionUtils.needsTransaction(workerManagerSession, wi)) {
+        if (SessionUtils.needsTransaction(workerManagerSession, wi, servicesImpl)) {
             // use separate transaction bean to avoid deadlock
             return dispatcherProcessTransSession.processWithTransaction(adminInfo, wi, request, requestContext);
         } else {

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/InternalProcessSessionBean.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/InternalProcessSessionBean.java
@@ -137,7 +137,7 @@ public class InternalProcessSessionBean implements InternalProcessSessionLocal {
             throws IllegalRequestException, CryptoTokenOfflineException,
             SignServerException {
         requestContext.setServices(servicesImpl);
-        if (SessionUtils.needsTransaction(workerManagerSession, wi)) {
+        if (SessionUtils.needsTransaction(workerManagerSession, wi, servicesImpl)) {
             // use separate transaction bean to avoid deadlock
             return internalProcessTransSession.processWithTransaction(adminInfo, wi, request, requestContext);
         } else {

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/ProcessSessionBean.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/ProcessSessionBean.java
@@ -336,7 +336,7 @@ public class ProcessSessionBean implements ProcessSessionRemote, ProcessSessionL
             LOG.debug(">process: " + wi);
         }
         
-        if (SessionUtils.needsTransaction(workerManagerSession, wi)) {
+        if (SessionUtils.needsTransaction(workerManagerSession, wi, servicesImpl)) {
             // use separate transaction bean to avoid deadlock
             return processTransSession.processWithTransaction(adminInfo, wi, request, requestContext);
         } else {

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/ServiceTimerSessionBean.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/ServiceTimerSessionBean.java
@@ -160,6 +160,7 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
             ITimedService timedService = null;
             boolean run = false;
             boolean isSingleton = false;
+            boolean requiresTransaction = false;
             UserTransaction ut = sessionCtx.getUserTransaction();
             try {
                 ut.begin();
@@ -168,6 +169,7 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
                 timedService = (ITimedService) worker;
                 sessionCtx.getTimerService().createSingleActionTimer(timedService.getNextInterval(), new TimerConfig(timerInfo, false));
                 isSingleton = timedService.isSingleton();
+                requiresTransaction = timedService.requiresTransaction(servicesImpl);
                 if (!isSingleton) {
                     run = true;
                 } else {
@@ -195,11 +197,17 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
                 }
             }
 
+            ut = sessionCtx.getUserTransaction();
             if (run) {
                 if (serviceConfig != null && timedService != null) {
                     try {
                         if (timedService.isActive() && timedService.getNextInterval() != ITimedService.DONT_EXECUTE) {
-                            timedService.work(new ServiceContext(servicesImpl));
+                            if(requiresTransaction) {
+                                ut.begin();
+                                timedService.work(new ServiceContext(servicesImpl));
+                                ut.commit();
+                            }
+
                             serviceConfig.setLastRunTimestamp(new Date());
                             for (final ITimedService.LogType logType :
                                     timedService.getLogTypes()) {
@@ -225,7 +233,8 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
                             }
                             
                         }
-                    } catch (ServiceExecutionFailedException e) {
+                    } catch (ServiceExecutionFailedException | SystemException | HeuristicRollbackException | NotSupportedException |
+                             HeuristicMixedException | RollbackException e) {
                         // always log to error log, regardless of log types
                         // setup for service run logging
                         LOG.error("Service" + timerInfo + " execution failed. ", e);
@@ -240,6 +249,11 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
                                     timerInfo.toString(),
                                     Collections.<String, Object>singletonMap("Message", e.getMessage()));
                         }
+                        try {
+                            ut.rollback();
+                        } catch (SystemException ex) {
+                            LOG.error("Rollback failed.", e);
+                        }
                     } catch (RuntimeException e) {
                         /*
                          * DSS-377:
@@ -251,6 +265,11 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
                          * since it is some kind of catastrophic failure..
                          */
                         LOG.error("Service worker execution failed.", e);
+                        try {
+                            ut.rollback();
+                        } catch (SystemException ex) {
+                            throw new RuntimeException("Rollback failed", ex);
+                        }
                     }
                 } else {
                     LOG.error("Service with ID " + timerInfo + " not found.");

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/ServiceTimerSessionBean.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/ServiceTimerSessionBean.java
@@ -206,6 +206,8 @@ public class ServiceTimerSessionBean implements ServiceTimerSessionLocal {
                                 ut.begin();
                                 timedService.work(new ServiceContext(servicesImpl));
                                 ut.commit();
+                            } else {
+                                timedService.work(new ServiceContext(servicesImpl));
                             }
 
                             serviceConfig.setLastRunTimestamp(new Date());

--- a/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/SessionUtils.java
+++ b/signserver/modules/SignServer-ejb/src/main/java/org/signserver/ejb/SessionUtils.java
@@ -17,6 +17,8 @@ import org.signserver.common.WorkerIdentifier;
 import org.signserver.ejb.worker.impl.PreloadedWorkerConfig;
 import org.signserver.ejb.worker.impl.WorkerManagerSingletonBean;
 import org.signserver.ejb.worker.impl.WorkerWithComponents;
+import org.signserver.server.IServices;
+import org.signserver.server.IWorker;
 
 /**
  * Utility functions for session beans.
@@ -33,13 +35,14 @@ public class SessionUtils {
      * @return true if the request needs a transaction
      */
     public static boolean needsTransaction(final WorkerManagerSingletonBean session,
-                                           final WorkerIdentifier wi) {
+                                           final WorkerIdentifier wi, IServices services) {
         try {
-            final WorkerWithComponents worker = session.getWorkerWithComponents(wi);
-            final PreloadedWorkerConfig pwc = worker.getPreloadedConfig();
+            final WorkerWithComponents workerWithComponents = session.getWorkerWithComponents(wi);
+            final IWorker worker = workerWithComponents.getWorker();
+            final PreloadedWorkerConfig pwc = workerWithComponents.getPreloadedConfig();
 
-            return !worker.getArchivers().isEmpty() ||
-                   !pwc.isDisableKeyUsageCounter() || pwc.isKeyUsageLimitSpecified();
+            return !workerWithComponents.getArchivers().isEmpty() ||
+                   !pwc.isDisableKeyUsageCounter() || pwc.isKeyUsageLimitSpecified() || worker.requiresTransaction(services);
         } catch (NoSuchWorkerException e) {
             return false;
         }


### PR DESCRIPTION
## Describe your changes

There are use cases, when siging worker needs to be executed in transaction because it interacts with the database. Typically, when the keys are stored in the database, or some other information needs to be updated during signing execution.

This implementation introduces feature to turn on the transaction handling for other use cases then for key usage counter or archiving. Specifically for signing and timed services.

There is a new interface requiresTransaction implemented, which is false by default.

## How has this been tested?

Tested and used in production by CZERTAINLY Signing modules.

## Checklist before requesting a review
<!--- To check or uncheck a box, switch between "[x]" and "[ ]" below. -->

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../../CONTRIBUTING.md).
