### PR TITLE
Race Condition vulnerability

### DIFF
--- a/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cesecore/util/FileTools.java
+++ b/signserver/modules/SignServer-Server/src/main/java/org/signserver/server/cesecore/util/FileTools.java
@@ -28,6 +28,7 @@ import java.io.PrintStream;
 import java.text.Collator;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.nio.file.Files;
 
 import org.apache.log4j.Logger;
 
@@ -178,15 +179,12 @@ public abstract class FileTools {
     }
 
     public static File createTempDirectory(File location) throws IOException {
-        final File temp = File.createTempFile("tmp", Long.toString(System.nanoTime()), location);
-        if (!(temp.delete())) {
-            throw new IOException("Could not delete temp file: " + temp.getAbsolutePath());
+        // Use Files.createTempDirectory to avoid race condition
+        if (location != null) {
+            return Files.createTempDirectory(location.toPath(), "tmp" + Long.toString(System.nanoTime())).toFile();
+        } else {
+            return Files.createTempDirectory("tmp" + Long.toString(System.nanoTime())).toFile();
         }
-        //Known race condition exists here, not sure what an attacker would accomplish with it though
-        if (!temp.mkdir()) {
-            throw new IOException("Could not create temp directory: " + temp.getAbsolutePath());
-        }
-        return temp;
     }
     
     /**


### PR DESCRIPTION
This PR fixes a race condition vulnerability in the createTempDirectory method that could allow attackers to exploit the gap between file deletion and directory creation

**Problem**
The original implementation used an unsafe pattern:
1. Create a temporary file with File.createTempFile() 
2. Delete the file with temp.delete()
3. Create a directory with the same name using temp.mkdir()

This creates a window where an attacker could:
- Create a symbolic link pointing to sensitive directories 
- Create files/directories they control
- Potentially escalate privileges or access unauthorized resources

**Solution**
Replace the unsafe temporary directory creation with Files.createTempDirectory() from Java NIO.2, which creates directories atomically and securely without the race condition

References:
https://cwe.mitre.org/data/definitions/362.html
https://github.com/UniversaBlockchain/universa/commit/1e34b1804842a7a2ba27fa9f4210a6fcb340d517